### PR TITLE
refactor: convert thiserror to snafu and remove anyhow in public apis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -75,44 +75,47 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arrayref"
@@ -125,45 +128,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
- "synstructure",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
 
 [[package]]
 name = "async-compat"
@@ -180,13 +144,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.87"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -228,15 +192,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backon"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970d91570c01a8a5959b36ad7dd1c30642df24b6b3068710066f6809f7033bb7"
+checksum = "302eaff5357a264a2c42f127ecb8bac761cf99749fc3dc95677e2743991f99e7"
 dependencies = [
  "fastrand",
  "gloo-timers",
@@ -245,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -297,9 +261,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "binary-merge"
@@ -330,9 +294,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "blake3"
@@ -363,10 +327,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "102dbef1187b1893e6dfe05a774e79fd52265f49f214f6879c8ff49f52c8188b"
 
 [[package]]
-name = "bumpalo"
-version = "3.17.0"
+name = "btparse"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "387e80962b798815a2b5c4bcfdb6bf626fa922ffe9f74e373103b858738e9f31"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -376,18 +346,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.14"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
@@ -400,9 +370,9 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -423,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -433,7 +403,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -449,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -459,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -471,21 +441,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cobs"
@@ -494,10 +464,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
-name = "colorchoice"
-version = "1.0.3"
+name = "color-backtrace"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "2123a5984bd52ca861c66f66a9ab9883b27115c607f801f86c1bc2a84eb69f0f"
+dependencies = [
+ "backtrace",
+ "btparse",
+ "termcolor",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -507,15 +488,6 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -532,11 +504,11 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cordyceps"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec10f0a762d93c4498d2e97a333805cb6250d60bead623f71d8034f9a4152ba3"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
 dependencies = [
- "loom 0.5.6",
+ "loom",
  "tracing",
 ]
 
@@ -552,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -577,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -598,9 +570,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -689,39 +661,25 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "der_derive",
  "pem-rfc7468",
  "zeroize",
-]
-
-[[package]]
-name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
-dependencies = [
- "asn1-rs",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
 ]
 
 [[package]]
@@ -732,14 +690,14 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -770,7 +728,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
  "unicode-xid",
 ]
 
@@ -782,7 +740,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
  "unicode-xid",
 ]
 
@@ -811,7 +769,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -893,27 +851,27 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "enumflags2"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -939,12 +897,12 @@ checksum = "a02a5d186d7bf1cb21f1f95e1a9cfa5c1f2dcd803a47aad454423ceec13525c5"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -973,9 +931,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1068,7 +1026,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1134,28 +1092,16 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.7.5"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
 dependencies = [
  "cc",
- "libc",
- "log",
- "rustversion",
- "windows 0.48.0",
-]
-
-[[package]]
-name = "generator"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
-dependencies = [
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows 0.58.0",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -1171,14 +1117,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1222,16 +1168,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http 1.3.1",
  "indexmap",
  "slab",
  "tokio",
@@ -1250,15 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1271,7 +1211,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1316,7 +1256,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ring",
  "thiserror 2.0.12",
  "tinyvec",
@@ -1338,7 +1278,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.1",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.12",
@@ -1367,20 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "hmac-sha256"
-version = "1.1.8"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8575493d277c9092b988c780c94737fb9fd8651a1001e16bee3eccfc1baedb"
-
-[[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi",
-]
+checksum = "ad6880c8d4a9ebf39c6e8b77007ce223f646a4d21ce29d99f70cb16420545425"
 
 [[package]]
 name = "hostname-validator"
@@ -1401,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -1417,18 +1346,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body",
  "pin-project-lite",
 ]
@@ -1455,7 +1384,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body",
  "httparse",
  "httpdate",
@@ -1468,12 +1397,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1481,7 +1409,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -1490,14 +1418,17 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1507,16 +1438,17 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -1530,21 +1462,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1554,30 +1487,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1585,65 +1498,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -1659,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1677,12 +1577,12 @@ dependencies = [
  "attohttpc",
  "bytes",
  "futures",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body-util",
  "hyper",
  "hyper-util",
  "log",
- "rand 0.9.0",
+ "rand 0.9.1",
  "tokio",
  "url",
  "xmltree",
@@ -1690,12 +1590,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1747,18 +1647,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "iroh"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca758f4ce39ae3f07de922be6c73de6a48a07f39554e78b5745585652ce38f5"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#bc6e9e3077a62f61f25efcd0bc93540006222e18"
 dependencies = [
  "aead",
  "anyhow",
- "atomic-waker",
  "backon",
  "bytes",
  "cfg_aliases",
- "concurrent-queue",
  "crypto_box",
  "data-encoding",
  "der",
@@ -1768,34 +1675,37 @@ dependencies = [
  "futures-util",
  "getrandom 0.3.3",
  "hickory-resolver",
- "http 1.2.0",
+ "http 1.3.1",
  "igd-next",
  "instant",
  "iroh-base",
  "iroh-metrics 0.34.0",
- "iroh-quinn",
+ "iroh-quinn 0.14.0",
  "iroh-quinn-proto",
  "iroh-quinn-udp",
  "iroh-relay",
  "n0-future",
+ "n0-snafu",
+ "n0-watcher",
+ "nested_enum_utils 0.2.2",
  "netdev",
  "netwatch",
  "pin-project",
  "pkarr",
  "portmapper",
  "rand 0.8.5",
- "rcgen",
  "reqwest",
  "ring",
  "rustls",
+ "rustls-pki-types",
  "rustls-webpki",
  "serde",
  "smallvec",
+ "snafu",
  "spki",
  "strum",
  "stun-rs",
  "surge-ping",
- "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-stream",
@@ -1803,25 +1713,25 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "webpki-roots",
- "x509-parser",
+ "webpki-roots 0.26.11",
  "z32",
 ]
 
 [[package]]
 name = "iroh-base"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91ac4aaab68153d726c4e6b39c30f9f9253743f0e25664e52f4caeb46f48d11"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#bc6e9e3077a62f61f25efcd0bc93540006222e18"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
  "derive_more 1.0.0",
  "ed25519-dalek",
+ "n0-snafu",
+ "nested_enum_utils 0.2.2",
  "postcard",
  "rand_core 0.6.4",
  "serde",
- "thiserror 2.0.12",
+ "snafu",
  "url",
 ]
 
@@ -1846,10 +1756,11 @@ dependencies = [
  "iroh-base",
  "iroh-io",
  "iroh-metrics 0.32.0",
- "iroh-quinn",
+ "iroh-quinn 0.13.0",
  "iroh-test",
  "irpc",
  "n0-future",
+ "n0-watcher",
  "nested_enum_utils 0.1.0",
  "postcard",
  "proptest",
@@ -1924,7 +1835,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1948,13 +1859,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-quinn"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde160ebee7aabede6ae887460cd303c8b809054224815addf1469d54a6fcf7"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "iroh-quinn-proto",
+ "iroh-quinn-udp",
+ "pin-project-lite",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
 name = "iroh-quinn-proto"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "929d5d8fa77d5c304d3ee7cae9aede31f13908bd049f9de8c7c0094ad6f7c535"
 dependencies = [
  "bytes",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "rand 0.8.5",
  "ring",
  "rustc-hash",
@@ -1985,26 +1916,26 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63f122cdfaa4b4e0e7d6d3921d2b878f42a0c6d3ee5a29456dc3f5ab5ec931f"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#bc6e9e3077a62f61f25efcd0bc93540006222e18"
 dependencies = [
- "anyhow",
  "bytes",
  "cfg_aliases",
  "data-encoding",
  "derive_more 1.0.0",
  "getrandom 0.3.3",
  "hickory-resolver",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body-util",
  "hyper",
  "hyper-util",
  "iroh-base",
  "iroh-metrics 0.34.0",
- "iroh-quinn",
+ "iroh-quinn 0.14.0",
  "iroh-quinn-proto",
- "lru 0.12.5",
+ "lru",
  "n0-future",
+ "n0-snafu",
+ "nested_enum_utils 0.2.2",
  "num_enum",
  "pin-project",
  "pkarr",
@@ -2012,19 +1943,19 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "rustls",
+ "rustls-pki-types",
  "rustls-webpki",
  "serde",
  "sha1",
+ "snafu",
  "strum",
- "stun-rs",
- "thiserror 2.0.12",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "tokio-websockets",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.11",
  "ws_stream_wasm",
  "z32",
 ]
@@ -2050,7 +1981,7 @@ dependencies = [
  "anyhow",
  "futures-buffered",
  "futures-util",
- "iroh-quinn",
+ "iroh-quinn 0.13.0",
  "irpc-derive",
  "n0-future",
  "postcard",
@@ -2083,9 +2014,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -2133,15 +2064,15 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litrs"
@@ -2151,9 +2082,9 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2161,22 +2092,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
-
-[[package]]
-name = "loom"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
-dependencies = [
- "cfg-if",
- "generator 0.7.5",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "loom"
@@ -2185,7 +2103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
  "cfg-if",
- "generator 0.8.4",
+ "generator",
  "scoped-tls",
  "tracing",
  "tracing-subscriber",
@@ -2193,24 +2111,18 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.2",
-]
-
-[[package]]
-name = "lru"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
-name = "match_cfg"
-version = "0.1.0"
+name = "lru-slab"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -2229,40 +2141,28 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2274,7 +2174,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
- "loom 0.7.2",
+ "loom",
  "parking_lot",
  "portable-atomic",
  "rustc_version",
@@ -2303,6 +2203,30 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
+]
+
+[[package]]
+name = "n0-snafu"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4fed465ff57041f29db78a9adc8864296ef93c6c16029f9e192dc303404ebd0"
+dependencies = [
+ "anyhow",
+ "btparse",
+ "color-backtrace",
+ "snafu",
+ "tracing-error",
+]
+
+[[package]]
+name = "n0-watcher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f216d4ebc5fcf9548244803cbb93f488a2ae160feba3706cd17040d69cf7a368"
+dependencies = [
+ "derive_more 1.0.0",
+ "n0-future",
+ "snafu",
 ]
 
 [[package]]
@@ -2378,7 +2302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0800eae8638a299eaa67476e1c6b6692922273e0f7939fd188fc861c837b9cd2"
 dependencies = [
  "anyhow",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "byteorder",
  "libc",
  "log",
@@ -2427,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eeaa5f7505c93c5a9b35ba84fd21fb8aa3f24678c76acfe8716af7862fb07a"
+checksum = "2a829a830199b14989f9bccce6136ab928ab48336ab1f8b9002495dbbbb2edbe"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2439,12 +2363,14 @@ dependencies = [
  "js-sys",
  "libc",
  "n0-future",
+ "n0-watcher",
  "nested_enum_utils 0.2.2",
  "netdev",
  "netlink-packet-core",
  "netlink-packet-route 0.23.0",
  "netlink-proto",
  "netlink-sys",
+ "pin-project-lite",
  "serde",
  "snafu",
  "socket2",
@@ -2454,7 +2380,7 @@ dependencies = [
  "tracing",
  "web-sys",
  "windows 0.59.0",
- "windows-result 0.3.1",
+ "windows-result",
  "wmi",
 ]
 
@@ -2465,16 +2391,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "ntimestamp"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,7 +2398,7 @@ checksum = "c50f94c405726d3e0095e89e72f75ce7f6587b94a8bd8dc8054b73f65c0fd68c"
 dependencies = [
  "base32",
  "document-features",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "httpdate",
  "js-sys",
  "once_cell",
@@ -2500,29 +2416,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -2535,23 +2432,24 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2564,23 +2462,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
-dependencies = [
- "asn1-rs",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 dependencies = [
  "critical-section",
  "portable-atomic",
 ]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "opaque-debug"
@@ -2608,9 +2503,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2618,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2662,9 +2557,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -2673,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2683,24 +2578,23 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -2717,22 +2611,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2762,9 +2656,9 @@ dependencies = [
  "ed25519-dalek",
  "futures-buffered",
  "futures-lite",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "log",
- "lru 0.13.0",
+ "lru",
  "ntimestamp",
  "reqwest",
  "self_cell",
@@ -2806,7 +2700,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2843,15 +2737,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portmapper"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6db66007eac4a0ec8331d0d20c734bd64f6445d64bbaf0d0a27fea7a054e36"
+checksum = "f651ba57abd6d766deb1b86f45b50c189db69204f20126e84f033168c1bf0853"
 dependencies = [
  "base64",
  "bytes",
@@ -2880,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "positioned-io"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccabfeeb89c73adf4081f0dca7f8e28dbda90981a222ceea37f619e93ea6afe9"
+checksum = "e8078ce4d22da5e8f57324d985cc9befe40c49ab0507a192d6be9e59584495c9"
 dependencies = [
  "libc",
  "winapi",
@@ -2914,6 +2808,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,11 +2824,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2964,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
@@ -3005,9 +2908,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -3032,22 +2935,22 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -3063,11 +2966,12 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -3077,17 +2981,19 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
- "getrandom 0.2.15",
- "rand 0.8.5",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.1",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3101,9 +3007,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.10"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3115,9 +3021,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -3151,13 +3057,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.1",
- "zerocopy 0.8.18",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3177,7 +3082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.1",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3186,26 +3091,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88e0da7a2c97baa202165137c158d0a2e824ac465d13d81046727b34cb247d3"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
- "zerocopy 0.8.18",
 ]
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3236,20 +3140,20 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0a72cd7140de9fc3e318823b883abf819c20d478ec89ce880466dc2ef263c6"
+checksum = "cef6a6d3a65ea334d6cdfb31fa2525c20184b7aa7bd1ad1e2e37502610d4609f"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -3269,19 +3173,19 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efd944f26afa2406cbbabff39fac533c9bc24b13d7f1f12e14ae3e7bdc66cdb"
+checksum = "78c81d000a2c524133cc00d2f92f019d399e57906c3b7119271a2495354fe895"
 dependencies = [
  "cfg-if",
  "libc",
  "rustix",
- "windows 0.60.0",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3336,30 +3240,26 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3369,35 +3269,31 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
- "windows-registry",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
-dependencies = [
- "hostname",
- "quick-error",
-]
+checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "ring"
-version = "0.17.9"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3405,9 +3301,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -3425,21 +3321,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusticata-macros"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3448,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "log",
  "once_cell",
@@ -3474,30 +3361,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e012c45844a1790332c9386ed4ca3a06def221092eda277e6f079728f8ea99da"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -3508,8 +3387,8 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.52.0",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3520,9 +3399,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3531,9 +3410,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-fork"
@@ -3549,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa20"
@@ -3598,8 +3477,8 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.8.0",
- "core-foundation 0.10.0",
+ "bitflags 2.9.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3617,15 +3496,15 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
+checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "send_wrapper"
@@ -3650,14 +3529,14 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -3715,9 +3594,9 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3741,9 +3620,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -3769,23 +3648,20 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
@@ -3796,6 +3672,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320b01e011bf8d5d7a4a4a4be966d9160968935849c83b918827f6a435e7f627"
 dependencies = [
+ "backtrace",
  "snafu-derive",
 ]
 
@@ -3808,7 +3685,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3872,7 +3749,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "struct_iterable_internal",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3890,7 +3767,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3901,7 +3778,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3923,7 +3800,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3947,7 +3824,7 @@ dependencies = [
  "precis-core",
  "precis-profiles",
  "quoted-string-parser",
- "rand 0.9.0",
+ "rand 0.9.1",
 ]
 
 [[package]]
@@ -3965,7 +3842,7 @@ dependencies = [
  "hex",
  "parking_lot",
  "pnet_packet",
- "rand 0.9.0",
+ "rand 0.9.1",
  "socket2",
  "thiserror 1.0.69",
  "tokio",
@@ -3985,9 +3862,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4016,13 +3893,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4031,7 +3908,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4054,11 +3931,10 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
@@ -4067,15 +3943,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-strategy"
-version = "0.4.0"
+name = "termcolor"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf41af45e3f54cc184831d629d41d5b2bda8297e29c81add7ae4f362ed5e01b"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "test-strategy"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95eb2d223f5cd3ec8dd7874cf4ada95c9cf2b5ed84ecfb1046d9aefee0c28b12"
 dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4110,7 +3995,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4121,56 +4006,43 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.38"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb041120f25f8fbe8fd2dbe4671c7c2ed74d83be2e7a77529bf7e0790ae3f472"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
- "itoa",
  "js-sys",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
- "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
-
-[[package]]
-name = "time-macros"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
-dependencies = [
- "num-conv",
- "time-core",
-]
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4178,9 +4050,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4217,7 +4089,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4244,16 +4116,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -4270,9 +4142,9 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "getrandom 0.3.3",
- "http 1.2.0",
+ "http 1.3.1",
  "httparse",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ring",
  "rustls-pki-types",
  "simdutf8",
@@ -4283,15 +4155,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -4309,6 +4181,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -4339,23 +4229,33 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4405,7 +4305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4443,9 +4343,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
@@ -4491,12 +4391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4510,11 +4404,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.15.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4559,9 +4455,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -4594,7 +4490,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -4629,7 +4525,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4678,27 +4574,45 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.8"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.1",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.1",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "widestring"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "winapi"
@@ -4733,41 +4647,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
 dependencies = [
  "windows-core 0.59.0",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
 name = "windows"
-version = "0.60.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf874e74c7a99773e62b1c671427abf01a425e77c3d3fb9fb1e4883ea934529"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.60.1",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link",
  "windows-numerics",
@@ -4775,33 +4670,11 @@ dependencies = [
 
 [[package]]
 name = "windows-collections"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5467f79cc1ba3f52ebb2ed41dbb459b8e7db636cc3429458d9a852e15bc24dec"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.60.1",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4811,44 +4684,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
 dependencies = [
  "windows-implement 0.59.0",
- "windows-interface 0.59.0",
- "windows-result 0.3.1",
+ "windows-interface",
+ "windows-result",
  "windows-strings 0.3.1",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.60.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca21a92a9cae9bf4ccae5cf8368dce0837100ddf6e6d57936749e85f152f6247"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.59.0",
- "windows-interface 0.59.0",
+ "windows-implement 0.60.0",
+ "windows-interface",
  "windows-link",
- "windows-result 0.3.1",
- "windows-strings 0.3.1",
+ "windows-result",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a787db4595e7eb80239b74ce8babfb1363d8e343ab072f2ffe901400c03349f0"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.60.1",
+ "windows-core 0.61.2",
  "windows-link",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4859,84 +4722,54 @@ checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.58.0"
+version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26fd936d991781ea39e87c3a27285081e3c0da5ca0fcbc02d368cc6f52ff01"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-numerics"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005dea54e2f6499f2cee279b8f703b3cf3b5734a2d8d21867c8f44003182eeed"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.60.1",
+ "windows-core 0.61.2",
  "windows-link",
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
-dependencies = [
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4944,6 +4777,15 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -4982,6 +4824,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -5032,9 +4883,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -5044,6 +4895,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5228,9 +5088,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.3"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -5251,7 +5111,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -5270,16 +5130,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "ws_stream_wasm"
@@ -5301,27 +5155,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "x509-parser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
-dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
 name = "xml-rs"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "xmltree"
@@ -5343,9 +5180,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -5355,13 +5192,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -5373,43 +5210,22 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79386d31a42a4996e3336b0919ddb90f81112af416270cff95b5f5af22b839c2"
-dependencies = [
- "zerocopy-derive 0.8.18",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76331675d372f91bf8d17e13afbd5fe639200b73d01f0fc748bb059f9cca2db7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5429,7 +5245,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -5440,10 +5256,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5452,11 +5279,11 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.104",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,7 +1680,7 @@ dependencies = [
  "instant",
  "iroh-base",
  "iroh-metrics 0.34.0",
- "iroh-quinn 0.14.0",
+ "iroh-quinn",
  "iroh-quinn-proto",
  "iroh-quinn-udp",
  "iroh-relay",
@@ -1756,7 +1756,7 @@ dependencies = [
  "iroh-base",
  "iroh-io",
  "iroh-metrics 0.32.0",
- "iroh-quinn 0.13.0",
+ "iroh-quinn",
  "iroh-test",
  "irpc",
  "n0-future",
@@ -1779,6 +1779,7 @@ dependencies = [
  "tempfile",
  "test-strategy",
  "testresult",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1837,26 +1838,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "iroh-quinn"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c6245c9ed906506ab9185e8d7f64857129aee4f935e899f398a3bd3b70338d"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "iroh-quinn-proto",
- "iroh-quinn-udp",
- "pin-project-lite",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
- "web-time",
 ]
 
 [[package]]
@@ -1931,7 +1912,7 @@ dependencies = [
  "hyper-util",
  "iroh-base",
  "iroh-metrics 0.34.0",
- "iroh-quinn 0.14.0",
+ "iroh-quinn",
  "iroh-quinn-proto",
  "lru",
  "n0-future",
@@ -1976,13 +1957,12 @@ dependencies = [
 [[package]]
 name = "irpc"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce3631786a8ad447d39cc5da18c659c1b31641dfefad4e9afc07a19ceccacc2"
+source = "git+https://github.com/n0-computer/irpc.git?branch=iroh-quinn-latest#04f7fa33f878496f8117776c675aa000f01fc50c"
 dependencies = [
  "anyhow",
  "futures-buffered",
  "futures-util",
- "iroh-quinn 0.13.0",
+ "iroh-quinn",
  "irpc-derive",
  "n0-future",
  "postcard",
@@ -1999,8 +1979,7 @@ dependencies = [
 [[package]]
 name = "irpc-derive"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efeabe1ee5615ea0416340b1a6d71a16f971495859c87fad48633b6497ee7a77"
+source = "git+https://github.com/n0-computer/irpc.git?branch=iroh-quinn-latest#04f7fa33f878496f8117776c675aa000f01fc50c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,7 +1778,6 @@ dependencies = [
  "tempfile",
  "test-strategy",
  "testresult",
- "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "iroh"
 version = "0.35.0"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#bc6e9e3077a62f61f25efcd0bc93540006222e18"
+source = "git+https://github.com/n0-computer/iroh.git?branch=ramfox%2Fticket-error#65a53a9d62a04ae13e5069d011353ba78cd31844"
 dependencies = [
  "aead",
  "anyhow",
@@ -1720,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.35.0"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#bc6e9e3077a62f61f25efcd0bc93540006222e18"
+source = "git+https://github.com/n0-computer/iroh.git?branch=ramfox%2Fticket-error#65a53a9d62a04ae13e5069d011353ba78cd31844"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -1761,7 +1761,6 @@ dependencies = [
  "irpc",
  "n0-future",
  "n0-snafu",
- "n0-watcher",
  "nested_enum_utils",
  "postcard",
  "proptest",
@@ -1898,7 +1897,7 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "0.35.0"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#bc6e9e3077a62f61f25efcd0bc93540006222e18"
+source = "git+https://github.com/n0-computer/iroh.git?branch=ramfox%2Fticket-error#65a53a9d62a04ae13e5069d011353ba78cd31844"
 dependencies = [
  "bytes",
  "cfg_aliases",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,7 +1687,7 @@ dependencies = [
  "n0-future",
  "n0-snafu",
  "n0-watcher",
- "nested_enum_utils 0.2.2",
+ "nested_enum_utils",
  "netdev",
  "netwatch",
  "pin-project",
@@ -1727,7 +1727,7 @@ dependencies = [
  "derive_more 1.0.0",
  "ed25519-dalek",
  "n0-snafu",
- "nested_enum_utils 0.2.2",
+ "nested_enum_utils",
  "postcard",
  "rand_core 0.6.4",
  "serde",
@@ -1760,8 +1760,9 @@ dependencies = [
  "iroh-test",
  "irpc",
  "n0-future",
+ "n0-snafu",
  "n0-watcher",
- "nested_enum_utils 0.1.0",
+ "nested_enum_utils",
  "postcard",
  "proptest",
  "rand 0.8.5",
@@ -1774,10 +1775,10 @@ dependencies = [
  "serde_json",
  "serde_test",
  "smallvec",
+ "snafu",
  "tempfile",
  "test-strategy",
  "testresult",
- "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1935,7 +1936,7 @@ dependencies = [
  "lru",
  "n0-future",
  "n0-snafu",
- "nested_enum_utils 0.2.2",
+ "nested_enum_utils",
  "num_enum",
  "pin-project",
  "pkarr",
@@ -2231,18 +2232,6 @@ dependencies = [
 
 [[package]]
 name = "nested_enum_utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f256ef99e7ac37428ef98c89bef9d84b590172de4bbfbe81b68a4cd3abadb32"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "nested_enum_utils"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43fa9161ed44d30e9702fe42bd78693bceac0fed02f647da749f36109023d3a3"
@@ -2364,7 +2353,7 @@ dependencies = [
  "libc",
  "n0-future",
  "n0-watcher",
- "nested_enum_utils 0.2.2",
+ "nested_enum_utils",
  "netdev",
  "netlink-packet-core",
  "netlink-packet-route 0.23.0",
@@ -2756,7 +2745,7 @@ dependencies = [
  "igd-next",
  "iroh-metrics 0.34.0",
  "libc",
- "nested_enum_utils 0.2.2",
+ "nested_enum_utils",
  "netwatch",
  "num_enum",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ derive_more = { version = "2.0.1", features = ["from", "try_from", "into", "debu
 futures-lite = "2.6.0"
 quinn = { package = "iroh-quinn", version = "0.13.0" }
 n0-future = "0.1.2"
+n0-watcher = "0.2.0"
 range-collections = { version = "0.4.6", features = ["serde"] }
 redb = "2.4.0"
 smallvec = { version = "1", features = ["serde", "const_new"] }
@@ -28,10 +29,10 @@ chrono = "0.4.39"
 nested_enum_utils = "0.1.0"
 ref-cast = "1.0.24"
 arrayvec = "0.7.6"
-iroh = "0.35.0"
+iroh = "0.35"
 self_cell = "1.1.0"
 genawaiter = { version = "0.99.1", features = ["futures03"] }
-iroh-base = "0.35.0"
+iroh-base = "0.35"
 reflink-copy = "0.1.24"
 irpc = { version = "0.4.0", features = ["rpc", "quinn_endpoint_setup", "message_spans", "stream", "derive"], default-features = false }
 iroh-metrics = { version = "0.32.0" }
@@ -56,3 +57,7 @@ walkdir = "2.5.0"
 hide-proto-docs = []
 metrics = []
 default = ["hide-proto-docs"]
+
+[patch.crates-io]
+iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ irpc = { version = "0.4.0", features = ["rpc", "quinn_endpoint_setup", "message_
 iroh-metrics = { version = "0.32.0" }
 hashlink = "0.10.0"
 futures-buffered = "0.2.11"
-thiserror = "2.0.12"
 
 [dev-dependencies]
 clap = { version = "4.5.31", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,13 @@ derive_more = { version = "2.0.1", features = ["from", "try_from", "into", "debu
 futures-lite = "2.6.0"
 quinn = { package = "iroh-quinn", version = "0.13.0" }
 n0-future = "0.1.2"
+n0-snafu = "0.2.0"
 n0-watcher = "0.2.0"
+nested_enum_utils = "0.2.1"
 range-collections = { version = "0.4.6", features = ["serde"] }
 redb = "2.4.0"
 smallvec = { version = "1", features = ["serde", "const_new"] }
-thiserror = "2.0.11"
+snafu = "0.8.5"
 tokio = { version = "1.43.0", features = ["full"] }
 tokio-util = { version = "0.7.13", features = ["full"] }
 tracing = "0.1.41"
@@ -26,7 +28,6 @@ serde = "1.0.217"
 postcard = { version = "1.1.1", features = ["experimental-derive", "use-std"] }
 data-encoding = "2.8.0"
 chrono = "0.4.39"
-nested_enum_utils = "0.1.0"
 ref-cast = "1.0.24"
 arrayvec = "0.7.6"
 iroh = "0.35"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,10 @@ bao-tree = { version = "0.15.1", features = ["experimental-mixed", "tokio_fsm", 
 bytes = { version = "1", features = ["serde"] }
 derive_more = { version = "2.0.1", features = ["from", "try_from", "into", "debug", "display", "deref", "deref_mut"] }
 futures-lite = "2.6.0"
-quinn = { package = "iroh-quinn", version = "0.13.0" }
+quinn = { package = "iroh-quinn", version = "0.14.0" }
 n0-future = "0.1.2"
 n0-snafu = "0.2.0"
 n0-watcher = "0.2.0"
-nested_enum_utils = "0.2.1"
 range-collections = { version = "0.4.6", features = ["serde"] }
 redb = "2.4.0"
 smallvec = { version = "1", features = ["serde", "const_new"] }
@@ -28,6 +27,7 @@ serde = "1.0.217"
 postcard = { version = "1.1.1", features = ["experimental-derive", "use-std"] }
 data-encoding = "2.8.0"
 chrono = "0.4.39"
+nested_enum_utils = "0.2.1"
 ref-cast = "1.0.24"
 arrayvec = "0.7.6"
 iroh = "0.35"
@@ -39,6 +39,7 @@ irpc = { version = "0.4.0", features = ["rpc", "quinn_endpoint_setup", "message_
 iroh-metrics = { version = "0.32.0" }
 hashlink = "0.10.0"
 futures-buffered = "0.2.11"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 clap = { version = "4.5.31", features = ["derive"] }
@@ -62,3 +63,5 @@ default = ["hide-proto-docs"]
 [patch.crates-io]
 iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
 iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+irpc = { git = "https://github.com/n0-computer/irpc.git", branch = "iroh-quinn-latest" }
+irpc-derive = { git = "https://github.com/n0-computer/irpc.git", branch = "iroh-quinn-latest" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ futures-lite = "2.6.0"
 quinn = { package = "iroh-quinn", version = "0.14.0" }
 n0-future = "0.1.2"
 n0-snafu = "0.2.0"
-n0-watcher = "0.2.0"
 range-collections = { version = "0.4.6", features = ["serde"] }
 redb = "2.4.0"
 smallvec = { version = "1", features = ["serde", "const_new"] }
@@ -61,7 +60,7 @@ metrics = []
 default = ["hide-proto-docs"]
 
 [patch.crates-io]
-iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
-iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "ramfox/ticket-error" }
+iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "ramfox/ticket-error" }
 irpc = { git = "https://github.com/n0-computer/irpc.git", branch = "iroh-quinn-latest" }
 irpc-derive = { git = "https://github.com/n0-computer/irpc.git", branch = "iroh-quinn-latest" }

--- a/examples/random_store.rs
+++ b/examples/random_store.rs
@@ -2,7 +2,7 @@ use std::{env, path::PathBuf, str::FromStr};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use iroh::SecretKey;
+use iroh::{SecretKey, Watcher};
 use iroh_base::ticket::NodeTicket;
 use iroh_blobs::{
     HashAndFormat,
@@ -240,7 +240,7 @@ async fn provide(args: ProvideArgs) -> anyhow::Result<()> {
     let router = iroh::protocol::Router::builder(endpoint.clone())
         .accept(iroh_blobs::ALPN, blobs)
         .spawn();
-    let addr = router.endpoint().node_addr().await?;
+    let addr = router.endpoint().node_addr().initialized().await?;
     let ticket = NodeTicket::from(addr.clone());
     println!("Node address: {:?}", addr);
     println!("ticket:\n{}", ticket);

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,9 +6,12 @@ use std::{io, net::SocketAddr, ops::Deref, sync::Arc};
 
 use iroh::Endpoint;
 use irpc::rpc::{Handler, listen};
+use n0_snafu::SpanTrace;
+use nested_enum_utils::common_fields;
 use proto::{Request, ShutdownRequest, SyncDbRequest};
 use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
+use snafu::{Backtrace, IntoError, Snafu};
 use tags::Tags;
 
 pub mod blobs;
@@ -20,70 +23,78 @@ pub use crate::{store::util::Tag, util::temp_tag::TempTag};
 
 pub(crate) type ApiClient = irpc::Client<proto::Command, proto::Request, proto::StoreService>;
 
-#[derive(Debug, thiserror::Error)]
+#[common_fields({
+    backtrace: Option<Backtrace>,
+    #[snafu(implicit)]
+    span_trace: SpanTrace,
+})]
+#[allow(missing_docs)]
+#[non_exhaustive]
+#[derive(Debug, Snafu)]
 pub enum RequestError {
     /// Request failed due to rpc error.
-    #[error("rpc error: {0}")]
-    Rpc(#[from] irpc::Error),
+    #[snafu(display("rpc error: {source}"))]
+    Rpc { source: irpc::Error },
     /// Request failed due an actual error.
-    #[error("inner error: {0}")]
-    Inner(#[from] Error),
+    #[snafu(display("inner error: {source}"))]
+    Inner { source: Error },
 }
 
-pub type RequestResult<T> = std::result::Result<T, RequestError>;
-
-impl From<irpc::channel::SendError> for RequestError {
-    fn from(e: irpc::channel::SendError) -> Self {
-        Self::Rpc(e.into())
+impl From<irpc::Error> for RequestError {
+    fn from(value: irpc::Error) -> Self {
+        RpcSnafu.into_error(value)
     }
 }
 
-impl From<irpc::channel::RecvError> for RequestError {
-    fn from(e: irpc::channel::RecvError) -> Self {
-        Self::Rpc(e.into())
-    }
-}
-
-impl From<irpc::RequestError> for RequestError {
-    fn from(e: irpc::RequestError) -> Self {
-        Self::Rpc(e.into())
-    }
-}
-
-impl From<irpc::rpc::WriteError> for RequestError {
-    fn from(e: irpc::rpc::WriteError) -> Self {
-        Self::Rpc(e.into())
+impl From<Error> for RequestError {
+    fn from(value: Error) -> Self {
+        InnerSnafu.into_error(value)
     }
 }
 
 impl From<io::Error> for RequestError {
-    fn from(e: io::Error) -> Self {
-        Self::Inner(e.into())
+    fn from(value: io::Error) -> Self {
+        InnerSnafu.into_error(value.into())
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+impl From<irpc::channel::RecvError> for RequestError {
+    fn from(value: irpc::channel::RecvError) -> Self {
+        RpcSnafu.into_error(value.into())
+    }
+}
+
+pub type RequestResult<T> = std::result::Result<T, RequestError>;
+
+#[common_fields({
+    backtrace: Option<Backtrace>,
+    #[snafu(implicit)]
+    span_trace: SpanTrace,
+})]
+#[allow(missing_docs)]
+#[non_exhaustive]
+#[derive(Debug, Snafu)]
 pub enum ExportBaoError {
-    #[error("send error: {0}")]
-    Send(#[from] irpc::channel::SendError),
-    #[error("recv error: {0}")]
-    Recv(#[from] irpc::channel::RecvError),
-    #[error("request error: {0}")]
-    Request(#[from] irpc::RequestError),
-    #[error("io error: {0}")]
-    Io(#[from] io::Error),
-    #[error("encode error: {0}")]
-    Inner(#[from] bao_tree::io::EncodeError),
+    #[snafu(display("send error: {source}"))]
+    Send { source: irpc::channel::SendError },
+    #[snafu(display("recv error: {source}"))]
+    Recv { source: irpc::channel::RecvError },
+    #[snafu(display("request error: {source}"))]
+    Request { source: irpc::RequestError },
+    #[snafu(display("io error: {source}"))]
+    ExportBaoIo { source: io::Error },
+    #[snafu(display("encode error: {source}"))]
+    ExportBaoInner { source: bao_tree::io::EncodeError },
 }
 
 impl From<ExportBaoError> for Error {
     fn from(e: ExportBaoError) -> Self {
         match e {
-            ExportBaoError::Send(e) => Self::Io(e.into()),
-            ExportBaoError::Recv(e) => Self::Io(e.into()),
-            ExportBaoError::Request(e) => Self::Io(e.into()),
-            ExportBaoError::Io(e) => Self::Io(e),
-            ExportBaoError::Inner(e) => Self::Io(e.into()),
+            ExportBaoError::Send { source, .. } => Self::Io(source.into()),
+            ExportBaoError::Recv { source, .. } => Self::Io(source.into()),
+            ExportBaoError::Request { source, .. } => Self::Io(source.into()),
+            ExportBaoError::ExportBaoIo { source, .. } => Self::Io(source),
+            ExportBaoError::ExportBaoInner { source, .. } => Self::Io(source.into()),
         }
     }
 }
@@ -91,11 +102,41 @@ impl From<ExportBaoError> for Error {
 impl From<irpc::Error> for ExportBaoError {
     fn from(e: irpc::Error) -> Self {
         match e {
-            irpc::Error::Recv(e) => Self::Recv(e),
-            irpc::Error::Send(e) => Self::Send(e),
-            irpc::Error::Request(e) => Self::Request(e),
-            irpc::Error::Write(e) => Self::Io(e.into()),
+            irpc::Error::Recv(e) => RecvSnafu.into_error(e),
+            irpc::Error::Send(e) => SendSnafu.into_error(e),
+            irpc::Error::Request(e) => RequestSnafu.into_error(e),
+            irpc::Error::Write(e) => ExportBaoIoSnafu.into_error(e.into()),
         }
+    }
+}
+
+impl From<io::Error> for ExportBaoError {
+    fn from(value: io::Error) -> Self {
+        ExportBaoIoSnafu.into_error(value)
+    }
+}
+
+impl From<irpc::channel::RecvError> for ExportBaoError {
+    fn from(value: irpc::channel::RecvError) -> Self {
+        RecvSnafu.into_error(value)
+    }
+}
+
+impl From<irpc::channel::SendError> for ExportBaoError {
+    fn from(value: irpc::channel::SendError) -> Self {
+        SendSnafu.into_error(value)
+    }
+}
+
+impl From<irpc::RequestError> for ExportBaoError {
+    fn from(value: irpc::RequestError) -> Self {
+        RequestSnafu.into_error(value)
+    }
+}
+
+impl From<bao_tree::io::EncodeError> for ExportBaoError {
+    fn from(value: bao_tree::io::EncodeError) -> Self {
+        ExportBaoInnerSnafu.into_error(value)
     }
 }
 
@@ -132,8 +173,8 @@ impl From<irpc::Error> for Error {
 impl From<RequestError> for Error {
     fn from(e: RequestError) -> Self {
         match e {
-            RequestError::Rpc(e) => Self::Io(e.into()),
-            RequestError::Inner(e) => e,
+            RequestError::Rpc { source, .. } => Self::Io(source.into()),
+            RequestError::Inner { source, .. } => source.into(),
         }
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -174,7 +174,7 @@ impl From<RequestError> for Error {
     fn from(e: RequestError) -> Self {
         match e {
             RequestError::Rpc { source, .. } => Self::Io(source.into()),
-            RequestError::Inner { source, .. } => source.into(),
+            RequestError::Inner { source, .. } => source,
         }
     }
 }

--- a/src/api/blobs.rs
+++ b/src/api/blobs.rs
@@ -430,7 +430,7 @@ impl Blobs {
         &self,
         hash: Hash,
         ranges: ChunkRanges,
-        stream: &mut quinn::RecvStream,
+        stream: &mut iroh::endpoint::RecvStream,
     ) -> RequestResult<()> {
         let reader = TokioStreamReader::new(stream);
         self.import_bao_reader(hash, ranges, reader).await?;

--- a/src/api/blobs.rs
+++ b/src/api/blobs.rs
@@ -1024,16 +1024,13 @@ impl ExportBaoProgress {
                     let mut data = vec![0u8; 64];
                     data[..32].copy_from_slice(parent.pair.0.as_bytes());
                     data[32..].copy_from_slice(parent.pair.1.as_bytes());
-                    target
-                        .write_all(&data)
-                        .await
-                        .map_err(|e| super::ExportBaoError::Io(e.into()))?;
+                    target.write_all(&data).await.map_err(io::Error::from)?;
                 }
                 EncodedItem::Leaf(leaf) => {
                     target
                         .write_chunk(leaf.data)
                         .await
-                        .map_err(|e| super::ExportBaoError::Io(e.into()))?;
+                        .map_err(io::Error::from)?;
                 }
                 EncodedItem::Done => break,
                 EncodedItem::Error(cause) => return Err(cause.into()),
@@ -1062,10 +1059,7 @@ impl ExportBaoProgress {
                     let mut data = vec![0u8; 64];
                     data[..32].copy_from_slice(parent.pair.0.as_bytes());
                     data[32..].copy_from_slice(parent.pair.1.as_bytes());
-                    writer
-                        .write_all(&data)
-                        .await
-                        .map_err(|e| super::ExportBaoError::Io(e.into()))?;
+                    writer.write_all(&data).await.map_err(io::Error::from)?;
                     progress.log_other_write(64);
                 }
                 EncodedItem::Leaf(leaf) => {
@@ -1073,7 +1067,7 @@ impl ExportBaoProgress {
                     writer
                         .write_chunk(leaf.data)
                         .await
-                        .map_err(|e| super::ExportBaoError::Io(e.into()))?;
+                        .map_err(io::Error::from)?;
                     progress.notify_payload_write(index, leaf.offset, len).await;
                 }
                 EncodedItem::Done => break,

--- a/src/api/downloader.rs
+++ b/src/api/downloader.rs
@@ -685,8 +685,8 @@ mod tests {
     use std::ops::Deref;
 
     use bao_tree::ChunkRanges;
+    use iroh::Watcher;
     use n0_future::StreamExt;
-    use n0_watcher::Watcher;
     use testresult::TestResult;
 
     use crate::{

--- a/src/api/downloader.rs
+++ b/src/api/downloader.rs
@@ -626,7 +626,7 @@ impl DialNode {
             Ok(Err(e)) => {
                 warn!("Failed to connect to node {}: {}", self.id, e);
                 *guard = SlotState::AttemptFailed(SystemTime::now());
-                Err(e)
+                Err(e.into())
             }
             Err(e) => {
                 warn!("Failed to connect to node {}: {}", self.id, e);
@@ -686,6 +686,7 @@ mod tests {
 
     use bao_tree::ChunkRanges;
     use n0_future::StreamExt;
+    use n0_watcher::Watcher;
     use testresult::TestResult;
 
     use crate::{
@@ -706,9 +707,9 @@ mod tests {
         let (r3, store3, _) = node_test_setup_fs(testdir.path().join("c")).await?;
         let tt1 = store1.add_slice("hello world").await?;
         let tt2 = store2.add_slice("hello world 2").await?;
-        let node1_addr = r1.endpoint().node_addr().await?;
+        let node1_addr = r1.endpoint().node_addr().initialized().await?;
         let node1_id = node1_addr.node_id;
-        let node2_addr = r2.endpoint().node_addr().await?;
+        let node2_addr = r2.endpoint().node_addr().initialized().await?;
         let node2_id = node2_addr.node_id;
         let swarm = Downloader::new(&store3, r3.endpoint());
         r3.endpoint().add_node_addr(node1_addr.clone())?;
@@ -745,9 +746,9 @@ mod tests {
                 format: crate::BlobFormat::HashSeq,
             })
             .await?;
-        let node1_addr = r1.endpoint().node_addr().await?;
+        let node1_addr = r1.endpoint().node_addr().initialized().await?;
         let node1_id = node1_addr.node_id;
-        let node2_addr = r2.endpoint().node_addr().await?;
+        let node2_addr = r2.endpoint().node_addr().initialized().await?;
         let node2_id = node2_addr.node_id;
         let swarm = Downloader::new(&store3, r3.endpoint());
         r3.endpoint().add_node_addr(node1_addr.clone())?;
@@ -814,9 +815,9 @@ mod tests {
                 format: crate::BlobFormat::HashSeq,
             })
             .await?;
-        let node1_addr = r1.endpoint().node_addr().await?;
+        let node1_addr = r1.endpoint().node_addr().initialized().await?;
         let node1_id = node1_addr.node_id;
-        let node2_addr = r2.endpoint().node_addr().await?;
+        let node2_addr = r2.endpoint().node_addr().initialized().await?;
         let node2_id = node2_addr.node_id;
         let swarm = Downloader::new(&store3, r3.endpoint());
         r3.endpoint().add_node_addr(node1_addr.clone())?;

--- a/src/api/remote.rs
+++ b/src/api/remote.rs
@@ -2,9 +2,9 @@
 //!
 //! The entry point is the [`Download`] struct.
 use genawaiter::sync::{Co, Gen};
+use iroh::endpoint::SendStream;
 use irpc::util::{AsyncReadVarintExt, WriteVarintExt};
 use n0_future::{Stream, StreamExt, io};
-use quinn::SendStream;
 use ref_cast::RefCast;
 
 use super::blobs::Bitfield;

--- a/src/api/remote.rs
+++ b/src/api/remote.rs
@@ -94,7 +94,8 @@ impl GetProgress {
 
     pub async fn complete(self) -> GetResult<Stats> {
         just_result(self.stream()).await.unwrap_or_else(|| {
-            Err(LocalFailureSnafu.into_error(anyhow::anyhow!("stream closed without result")))
+            Err(LocalFailureSnafu
+                .into_error(anyhow::anyhow!("stream closed without result").into()))
         })
     }
 }
@@ -503,7 +504,7 @@ impl Remote {
         let local = self
             .local(content)
             .await
-            .map_err(|e| LocalFailureSnafu.into_error(e))?;
+            .map_err(|e| LocalFailureSnafu.into_error(e.into()))?;
         if local.is_complete() {
             return Ok(Default::default());
         }
@@ -511,7 +512,7 @@ impl Remote {
         let conn = conn
             .connection()
             .await
-            .map_err(|e| LocalFailureSnafu.into_error(e))?;
+            .map_err(|e| LocalFailureSnafu.into_error(e.into()))?;
         let stats = self.execute_get_sink(conn, request, progress).await?;
         Ok(stats)
     }
@@ -682,7 +683,7 @@ impl Remote {
                         .await
                         .map_err(|e| LocalFailureSnafu.into_error(e.into()))?,
                 )
-                .map_err(|source| BadRequestSnafu.into_error(source))?;
+                .map_err(|source| BadRequestSnafu.into_error(source.into()))?;
                 // let mut hash_seq = LazyHashSeq::new(store.blobs().clone(), root);
                 loop {
                     let at_start_child = match next_child {
@@ -909,7 +910,8 @@ async fn get_blob_ranges_impl(
     };
     let complete = async move {
         handle.rx.await.map_err(|e| {
-            LocalFailureSnafu.into_error(anyhow::anyhow!("error reading from import stream: {e}"))
+            LocalFailureSnafu
+                .into_error(anyhow::anyhow!("error reading from import stream: {e}").into())
         })
     };
     let (_, end) = tokio::try_join!(complete, write)?;

--- a/src/get.rs
+++ b/src/get.rs
@@ -253,7 +253,7 @@ pub mod fsm {
         RequestTooBig,
         /// Error when writing the request to the [`SendStream`].
         #[error("write: {0}")]
-        Write(#[from] quinn::WriteError),
+        Write(#[from] iroh::endpoint::WriteError),
         /// Quic connection is closed.
         #[error("closed")]
         Closed(#[from] quinn::ClosedStream),

--- a/src/get.rs
+++ b/src/get.rs
@@ -129,7 +129,9 @@ pub mod fsm {
         let (mut writer, reader) = connection.open_bi().await?;
         let request = Request::GetMany(request);
         let request_bytes =
-            postcard::to_stdvec(&request).map_err(|e| GetError::BadRequest(e.into()))?;
+            postcard::to_stdvec(&request).map_err(|source| GetError::BadRequest {
+                source: source.into(),
+            })?;
         writer.write_all(&request_bytes).await?;
         writer.finish()?;
         let Request::GetMany(request) = request else {

--- a/src/get.rs
+++ b/src/get.rs
@@ -30,7 +30,7 @@ use iroh_io::TokioStreamReader;
 use n0_snafu::SpanTrace;
 use nested_enum_utils::common_fields;
 use serde::{Deserialize, Serialize};
-use snafu::{Backtrace, ResultExt, Snafu};
+use snafu::{Backtrace, IntoError, ResultExt, Snafu};
 use tracing::{debug, error};
 
 use crate::{Hash, protocol::ChunkRangesSeq, store::IROH_BLOCK_SIZE};
@@ -436,29 +436,35 @@ pub mod fsm {
     }
 
     /// Error that you can get from [`AtBlobHeader::next`]
-    #[derive(Debug, thiserror::Error)]
+    #[common_fields({
+        backtrace: Option<Backtrace>,
+        #[snafu(implicit)]
+        span_trace: SpanTrace,
+    })]
+    #[non_exhaustive]
+    #[derive(Debug, Snafu)]
     pub enum AtBlobHeaderNextError {
         /// Eof when reading the size header
         ///
         /// This indicates that the provider does not have the requested data.
-        #[error("not found")]
-        NotFound,
+        #[snafu(display("not found"))]
+        NotFound {},
         /// Quinn read error when reading the size header
-        #[error("read: {0}")]
-        Read(endpoint::ReadError),
+        #[snafu(display("read: {source}"))]
+        EndpointRead { source: endpoint::ReadError },
         /// Generic io error
-        #[error("io: {0}")]
-        Io(io::Error),
+        #[snafu(display("io: {source}"))]
+        Io { source: io::Error },
     }
 
     impl From<AtBlobHeaderNextError> for io::Error {
         fn from(cause: AtBlobHeaderNextError) -> Self {
             match cause {
-                AtBlobHeaderNextError::NotFound => {
+                AtBlobHeaderNextError::NotFound { .. } => {
                     io::Error::new(io::ErrorKind::UnexpectedEof, cause)
                 }
-                AtBlobHeaderNextError::Read(cause) => cause.into(),
-                AtBlobHeaderNextError::Io(cause) => cause,
+                AtBlobHeaderNextError::EndpointRead { source, .. } => source.into(),
+                AtBlobHeaderNextError::Io { source, .. } => source,
             }
         }
     }
@@ -468,14 +474,14 @@ pub mod fsm {
         pub async fn next(mut self) -> Result<(AtBlobContent, u64), AtBlobHeaderNextError> {
             let size = self.reader.read::<8>().await.map_err(|cause| {
                 if cause.kind() == io::ErrorKind::UnexpectedEof {
-                    AtBlobHeaderNextError::NotFound
+                    NotFoundSnafu.build()
                 } else if let Some(e) = cause
                     .get_ref()
                     .and_then(|x| x.downcast_ref::<endpoint::ReadError>())
                 {
-                    AtBlobHeaderNextError::Read(e.clone())
+                    EndpointReadSnafu.into_error(e.clone())
                 } else {
-                    AtBlobHeaderNextError::Io(cause)
+                    IoSnafu.into_error(cause)
                 }
             })?;
             self.misc.other_bytes_read += 8;
@@ -586,37 +592,49 @@ pub mod fsm {
     /// is not actually a [`ReadError`].
     ///
     /// [`ReadError`]: endpoint::ReadError
-    #[derive(Debug, thiserror::Error)]
+    #[common_fields({
+        backtrace: Option<Backtrace>,
+        #[snafu(implicit)]
+        span_trace: SpanTrace,
+    })]
+    #[non_exhaustive]
+    #[derive(Debug, Snafu)]
     pub enum DecodeError {
         /// A chunk was not found or invalid, so the provider stopped sending data
-        #[error("not found")]
-        NotFound,
+        #[snafu(display("not found"))]
+        ChunkNotFound {},
         /// A parent was not found or invalid, so the provider stopped sending data
-        #[error("parent not found {0:?}")]
-        ParentNotFound(TreeNode),
+        #[snafu(display("parent not found {node:?}"))]
+        ParentNotFound { node: TreeNode },
         /// A parent was not found or invalid, so the provider stopped sending data
-        #[error("chunk not found {0}")]
-        LeafNotFound(ChunkNum),
+        #[snafu(display("chunk not found {num}"))]
+        LeafNotFound { num: ChunkNum },
         /// The hash of a parent did not match the expected hash
-        #[error("parent hash mismatch: {0:?}")]
-        ParentHashMismatch(TreeNode),
+        #[snafu(display("parent hash mismatch: {node:?}"))]
+        ParentHashMismatch { node: TreeNode },
         /// The hash of a leaf did not match the expected hash
-        #[error("leaf hash mismatch: {0}")]
-        LeafHashMismatch(ChunkNum),
+        #[snafu(display("leaf hash mismatch: {num}"))]
+        LeafHashMismatch { num: ChunkNum },
         /// Error when reading from the stream
-        #[error("read: {0}")]
-        Read(endpoint::ReadError),
+        #[snafu(display("read: {source}"))]
+        Read { source: endpoint::ReadError },
         /// A generic io error
-        #[error("io: {0}")]
-        Io(#[from] io::Error),
+        #[snafu(display("io: {source}"))]
+        DecodeIo { source: io::Error },
+    }
+
+    impl DecodeError {
+        pub(crate) fn leaf_hash_mismatch(num: ChunkNum) -> Self {
+            LeafHashMismatchSnafu { num }.build()
+        }
     }
 
     impl From<AtBlobHeaderNextError> for DecodeError {
         fn from(cause: AtBlobHeaderNextError) -> Self {
             match cause {
-                AtBlobHeaderNextError::NotFound => Self::NotFound,
-                AtBlobHeaderNextError::Read(cause) => Self::Read(cause),
-                AtBlobHeaderNextError::Io(cause) => Self::Io(cause),
+                AtBlobHeaderNextError::NotFound { .. } => ChunkNotFoundSnafu.build(),
+                AtBlobHeaderNextError::EndpointRead { source, .. } => ReadSnafu.into_error(source),
+                AtBlobHeaderNextError::Io { source, .. } => DecodeIoSnafu.into_error(source),
             }
         }
     }
@@ -624,35 +642,47 @@ pub mod fsm {
     impl From<DecodeError> for io::Error {
         fn from(cause: DecodeError) -> Self {
             match cause {
-                DecodeError::ParentNotFound(_) => {
+                DecodeError::ParentNotFound { .. } => {
                     io::Error::new(io::ErrorKind::UnexpectedEof, cause)
                 }
-                DecodeError::LeafNotFound(_) => io::Error::new(io::ErrorKind::UnexpectedEof, cause),
-                DecodeError::Read(cause) => cause.into(),
-                DecodeError::Io(cause) => cause,
+                DecodeError::LeafNotFound { .. } => {
+                    io::Error::new(io::ErrorKind::UnexpectedEof, cause)
+                }
+                DecodeError::Read { source, .. } => source.into(),
+                DecodeError::DecodeIo { source, .. } => source,
                 _ => io::Error::other(cause),
             }
+        }
+    }
+
+    impl From<io::Error> for DecodeError {
+        fn from(value: io::Error) -> Self {
+            DecodeIoSnafu.into_error(value)
         }
     }
 
     impl From<bao_tree::io::DecodeError> for DecodeError {
         fn from(value: bao_tree::io::DecodeError) -> Self {
             match value {
-                bao_tree::io::DecodeError::ParentNotFound(x) => Self::ParentNotFound(x),
-                bao_tree::io::DecodeError::LeafNotFound(x) => Self::LeafNotFound(x),
-                bao_tree::io::DecodeError::ParentHashMismatch(node) => {
-                    Self::ParentHashMismatch(node)
+                bao_tree::io::DecodeError::ParentNotFound(x) => {
+                    ParentNotFoundSnafu { node: x }.build()
                 }
-                bao_tree::io::DecodeError::LeafHashMismatch(chunk) => Self::LeafHashMismatch(chunk),
+                bao_tree::io::DecodeError::LeafNotFound(x) => LeafNotFoundSnafu { num: x }.build(),
+                bao_tree::io::DecodeError::ParentHashMismatch(node) => {
+                    ParentHashMismatchSnafu { node }.build()
+                }
+                bao_tree::io::DecodeError::LeafHashMismatch(chunk) => {
+                    LeafHashMismatchSnafu { num: chunk }.build()
+                }
                 bao_tree::io::DecodeError::Io(cause) => {
                     if let Some(inner) = cause.get_ref() {
                         if let Some(e) = inner.downcast_ref::<endpoint::ReadError>() {
-                            Self::Read(e.clone())
+                            ReadSnafu.into_error(e.clone())
                         } else {
-                            Self::Io(cause)
+                            DecodeIoSnafu.into_error(cause)
                         }
                     } else {
-                        Self::Io(cause)
+                        DecodeIoSnafu.into_error(cause)
                     }
                 }
             }
@@ -918,28 +948,35 @@ pub mod fsm {
 }
 
 /// Error when processing a response
-#[derive(thiserror::Error, Debug)]
+#[common_fields({
+    backtrace: Option<Backtrace>,
+    #[snafu(implicit)]
+    span_trace: SpanTrace,
+})]
+#[allow(missing_docs)]
+#[non_exhaustive]
+#[derive(Debug, Snafu)]
 pub enum GetResponseError {
     /// Error when opening a stream
-    #[error("connection: {0}")]
-    Connection(#[from] endpoint::ConnectionError),
+    #[snafu(display("connection: {source}"))]
+    Connection { source: endpoint::ConnectionError },
     /// Error when writing the handshake or request to the stream
-    #[error("write: {0}")]
-    Write(#[from] endpoint::WriteError),
+    #[snafu(display("write: {source}"))]
+    Write { source: endpoint::WriteError },
     /// Error when reading from the stream
-    #[error("read: {0}")]
-    Read(#[from] endpoint::ReadError),
+    #[snafu(display("read: {source}"))]
+    Read { source: endpoint::ReadError },
     /// Error when decoding, e.g. hash mismatch
-    #[error("decode: {0}")]
-    Decode(bao_tree::io::DecodeError),
+    #[snafu(display("decode: {source}"))]
+    Decode { source: bao_tree::io::DecodeError },
     /// A generic error
-    #[error("generic: {0}")]
-    Generic(anyhow::Error),
+    #[snafu(display("generic: {source}"))]
+    Generic { source: anyhow::Error },
 }
 
 impl From<postcard::Error> for GetResponseError {
     fn from(cause: postcard::Error) -> Self {
-        Self::Generic(cause.into())
+        GenericSnafu.into_error(cause.into())
     }
 }
 
@@ -950,25 +987,25 @@ impl From<bao_tree::io::DecodeError> for GetResponseError {
                 // try to downcast to specific quinn errors
                 if let Some(source) = cause.source() {
                     if let Some(error) = source.downcast_ref::<endpoint::ConnectionError>() {
-                        return Self::Connection(error.clone());
+                        return ConnectionSnafu.into_error(error.clone());
                     }
                     if let Some(error) = source.downcast_ref::<endpoint::ReadError>() {
-                        return Self::Read(error.clone());
+                        return ReadSnafu.into_error(error.clone());
                     }
                     if let Some(error) = source.downcast_ref::<endpoint::WriteError>() {
-                        return Self::Write(error.clone());
+                        return WriteSnafu.into_error(error.clone());
                     }
                 }
-                Self::Generic(cause.into())
+                GenericSnafu.into_error(cause.into())
             }
-            _ => Self::Decode(cause),
+            _ => DecodeSnafu.into_error(cause),
         }
     }
 }
 
 impl From<anyhow::Error> for GetResponseError {
     fn from(cause: anyhow::Error) -> Self {
-        Self::Generic(cause)
+        GenericSnafu.into_error(cause)
     }
 }
 

--- a/src/get/error.rs
+++ b/src/get/error.rs
@@ -16,6 +16,11 @@ pub enum GetNotFoundError {
 }
 
 /// Failures for a get operation
+#[common_fields({
+    backtrace: Option<Backtrace>,
+    #[snafu(implicit)]
+    span_trace: SpanTrace,
+})]
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub enum GetError {

--- a/src/get/error.rs
+++ b/src/get/error.rs
@@ -108,24 +108,41 @@ pub enum IoCases {
 pub enum GetError {
     /// Hash not found, or a requested chunk for the hash not found.
     #[snafu(display("Data for hash not found"))]
-    NotFound { source: NotFoundCases },
+    NotFound {
+        #[snafu(source(from(NotFoundCases, Box::new)))]
+        source: Box<NotFoundCases>,
+    },
     /// Remote has reset the connection.
     #[snafu(display("Remote has reset the connection"))]
-    RemoteReset { source: RemoteResetCases },
+    RemoteReset {
+        #[snafu(source(from(RemoteResetCases, Box::new)))]
+        source: Box<RemoteResetCases>,
+    },
     /// Remote behaved in a non-compliant way.
     #[snafu(display("Remote behaved in a non-compliant way"))]
-    NoncompliantNode { source: NoncompliantNodeCases },
+    NoncompliantNode {
+        #[snafu(source(from(NoncompliantNodeCases, Box::new)))]
+        source: Box<NoncompliantNodeCases>,
+    },
 
     /// Network or IO operation failed.
     #[snafu(display("A network or IO operation failed"))]
-    Io { source: IoCases },
-
+    Io {
+        #[snafu(source(from(IoCases, Box::new)))]
+        source: Box<IoCases>,
+    },
     /// Our download request is invalid.
     #[snafu(display("Our download request is invalid"))]
-    BadRequest { source: BadRequestCases },
+    BadRequest {
+        #[snafu(source(from(BadRequestCases, Box::new)))]
+        source: Box<BadRequestCases>,
+    },
     /// Operation failed on the local node.
     #[snafu(display("Operation failed on the local node"))]
-    LocalFailure { source: LocalFailureCases },
+    LocalFailure {
+        #[snafu(source(from(LocalFailureCases, Box::new)))]
+        source: Box<LocalFailureCases>,
+    },
 }
 
 pub type GetResult<T> = std::result::Result<T, GetError>;

--- a/src/get/error.rs
+++ b/src/get/error.rs
@@ -1,43 +1,60 @@
 //! Error returned from get operations
 
 use iroh::endpoint::{self, ClosedStream};
+use n0_snafu::SpanTrace;
+use nested_enum_utils::common_fields;
+use snafu::{Backtrace, Snafu};
+
+#[common_fields({
+    backtrace: Option<Backtrace>,
+    #[snafu(implicit)]
+    span_trace: SpanTrace,
+})]
+#[derive(Debug, Snafu)]
+pub enum GetNotFoundError {
+    AtBlobHeader {},
+}
 
 /// Failures for a get operation
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Snafu)]
 pub enum GetError {
     /// Hash not found, or a requested chunk for the hash not found.
-    #[error("Data for hash not found")]
-    NotFound(#[source] anyhow::Error),
+    #[snafu(display("Data for hash not found"))]
+    NotFound { source: GetNotFoundError },
     /// Remote has reset the connection.
-    #[error("Remote has reset the connection")]
-    RemoteReset(#[source] anyhow::Error),
+    #[snafu(display("Remote has reset the connection"))]
+    RemoteReset { source: anyhow::Error },
     /// Remote behaved in a non-compliant way.
-    #[error("Remote behaved in a non-compliant way")]
-    NoncompliantNode(#[source] anyhow::Error),
+    #[snafu(display("Remote behaved in a non-compliant way"))]
+    NoncompliantNode { source: anyhow::Error },
 
     /// Network or IO operation failed.
-    #[error("A network or IO operation failed")]
-    Io(#[source] anyhow::Error),
+    #[snafu(display("A network or IO operation failed"))]
+    Io { source: anyhow::Error },
 
     /// Our download request is invalid.
-    #[error("Our download request is invalid")]
-    BadRequest(#[source] anyhow::Error),
+    #[snafu(display("Our download request is invalid"))]
+    BadRequest { source: anyhow::Error },
     /// Operation failed on the local node.
-    #[error("Operation failed on the local node")]
-    LocalFailure(#[source] anyhow::Error),
+    #[snafu(display("Operation failed on the local node"))]
+    LocalFailure { source: anyhow::Error },
 }
 
 pub type GetResult<T> = std::result::Result<T, GetError>;
 
 impl From<irpc::channel::SendError> for GetError {
     fn from(value: irpc::channel::SendError) -> Self {
-        Self::LocalFailure(value.into())
+        Self::LocalFailure {
+            source: value.into(),
+        }
     }
 }
 
 impl<T: Send + Sync + 'static> From<tokio::sync::mpsc::error::SendError<T>> for GetError {
     fn from(value: tokio::sync::mpsc::error::SendError<T>) -> Self {
-        Self::LocalFailure(value.into())
+        Self::LocalFailure {
+            source: value.into(),
+        }
     }
 }
 
@@ -49,40 +66,40 @@ impl From<endpoint::ConnectionError> for GetError {
             e @ ConnectionError::VersionMismatch => {
                 // > The peer doesn't implement any supported version
                 // unsupported version is likely a long time error, so this peer is not usable
-                GetError::NoncompliantNode(e.into())
+                GetError::NoncompliantNode { source: e.into() }
             }
             e @ ConnectionError::TransportError(_) => {
                 // > The peer violated the QUIC specification as understood by this implementation
                 // bad peer we don't want to keep around
-                GetError::NoncompliantNode(e.into())
+                GetError::NoncompliantNode { source: e.into() }
             }
             e @ ConnectionError::ConnectionClosed(_) => {
                 // > The peer's QUIC stack aborted the connection automatically
                 // peer might be disconnecting or otherwise unavailable, drop it
-                GetError::Io(e.into())
+                GetError::Io { source: e.into() }
             }
             e @ ConnectionError::ApplicationClosed(_) => {
                 // > The peer closed the connection
                 // peer might be disconnecting or otherwise unavailable, drop it
-                GetError::Io(e.into())
+                GetError::Io { source: e.into() }
             }
             e @ ConnectionError::Reset => {
                 // > The peer is unable to continue processing this connection, usually due to having restarted
-                GetError::RemoteReset(e.into())
+                GetError::RemoteReset { source: e.into() }
             }
             e @ ConnectionError::TimedOut => {
                 // > Communication with the peer has lapsed for longer than the negotiated idle timeout
-                GetError::Io(e.into())
+                GetError::Io { source: e.into() }
             }
             e @ ConnectionError::LocallyClosed => {
                 // > The local application closed the connection
                 // TODO(@divma): don't see how this is reachable but let's just not use the peer
-                GetError::Io(e.into())
+                GetError::Io { source: e.into() }
             }
             e @ ConnectionError::CidsExhausted => {
                 // > The connection could not be created because not enough of the CID space
                 // > is available
-                GetError::Io(e.into())
+                GetError::Io { source: e.into() }
             }
         }
     }
@@ -92,20 +109,24 @@ impl From<endpoint::ReadError> for GetError {
     fn from(value: endpoint::ReadError) -> Self {
         use endpoint::ReadError;
         match value {
-            e @ ReadError::Reset(_) => GetError::RemoteReset(e.into()),
+            e @ ReadError::Reset(_) => GetError::RemoteReset { source: e.into() },
             ReadError::ConnectionLost(conn_error) => conn_error.into(),
             ReadError::ClosedStream
             | ReadError::IllegalOrderedRead
             | ReadError::ZeroRttRejected => {
                 // all these errors indicate the peer is not usable at this moment
-                GetError::Io(value.into())
+                GetError::Io {
+                    source: value.into(),
+                }
             }
         }
     }
 }
 impl From<ClosedStream> for GetError {
     fn from(value: ClosedStream) -> Self {
-        GetError::Io(value.into())
+        GetError::Io {
+            source: value.into(),
+        }
     }
 }
 
@@ -113,11 +134,13 @@ impl From<quinn::WriteError> for GetError {
     fn from(value: quinn::WriteError) -> Self {
         use quinn::WriteError;
         match value {
-            e @ WriteError::Stopped(_) => GetError::RemoteReset(e.into()),
+            e @ WriteError::Stopped(_) => GetError::RemoteReset { source: e.into() },
             WriteError::ConnectionLost(conn_error) => conn_error.into(),
             WriteError::ClosedStream | WriteError::ZeroRttRejected => {
                 // all these errors indicate the peer is not usable at this moment
-                GetError::Io(value.into())
+                GetError::Io {
+                    source: value.into(),
+                }
             }
         }
     }
@@ -129,17 +152,17 @@ impl From<crate::get::fsm::ConnectedNextError> for GetError {
         match value {
             e @ PostcardSer { .. } => {
                 // serialization errors indicate something wrong with the request itself
-                GetError::BadRequest(e.into())
+                GetError::BadRequest { source: e.into() }
             }
             e @ RequestTooBig { .. } => {
                 // request will never be sent, drop it
-                GetError::BadRequest(e.into())
+                GetError::BadRequest { source: e.into() }
             }
             Write { source, .. } => source.into(),
             Closed { source, .. } => source.into(),
             e @ Io { .. } => {
                 // io errors are likely recoverable
-                GetError::Io(e.into())
+                GetError::Io { source: e.into() }
             }
         }
     }
@@ -149,15 +172,23 @@ impl From<crate::get::fsm::AtBlobHeaderNextError> for GetError {
     fn from(value: crate::get::fsm::AtBlobHeaderNextError) -> Self {
         use crate::get::fsm::AtBlobHeaderNextError::*;
         match value {
-            e @ NotFound { .. } => {
+            NotFound {
+                backtrace,
+                span_trace,
+            } => {
                 // > This indicates that the provider does not have the requested data.
                 // peer might have the data later, simply retry it
-                GetError::NotFound(e.into())
+                GetError::NotFound {
+                    source: GetNotFoundError::AtBlobHeader {
+                        backtrace,
+                        span_trace,
+                    },
+                }
             }
             EndpointRead { source, .. } => source.into(),
             e @ Io { .. } => {
                 // io errors are likely recoverable
-                GetError::Io(e.into())
+                GetError::Io { source: e.into() }
             }
         }
     }
@@ -168,18 +199,44 @@ impl From<crate::get::fsm::DecodeError> for GetError {
         use crate::get::fsm::DecodeError::*;
 
         match value {
-            e @ ChunkNotFound { .. } => GetError::NotFound(e.into()),
-            e @ ParentNotFound { .. } => GetError::NotFound(e.into()),
-            e @ LeafNotFound { .. } => GetError::NotFound(e.into()),
+            ChunkNotFound {
+                backtrace,
+                span_trace,
+            } => GetError::NotFound {
+                source: GetNotFoundError::AtBlobHeader {
+                    backtrace,
+                    span_trace,
+                },
+            },
+            ParentNotFound {
+                backtrace,
+                span_trace,
+                ..
+            } => GetError::NotFound {
+                source: GetNotFoundError::AtBlobHeader {
+                    backtrace,
+                    span_trace,
+                },
+            },
+            LeafNotFound {
+                backtrace,
+                span_trace,
+                ..
+            } => GetError::NotFound {
+                source: GetNotFoundError::AtBlobHeader {
+                    backtrace,
+                    span_trace,
+                },
+            },
             e @ ParentHashMismatch { .. } => {
                 // TODO(@divma): did the peer sent wrong data? is it corrupted? did we sent a wrong
                 // request?
-                GetError::NoncompliantNode(e.into())
+                GetError::NoncompliantNode { source: e.into() }
             }
             e @ LeafHashMismatch { .. } => {
                 // TODO(@divma): did the peer sent wrong data? is it corrupted? did we sent a wrong
                 // request?
-                GetError::NoncompliantNode(e.into())
+                GetError::NoncompliantNode { source: e.into() }
             }
             Read { source, .. } => source.into(),
             DecodeIo { source, .. } => source.into(),
@@ -191,6 +248,8 @@ impl From<std::io::Error> for GetError {
     fn from(value: std::io::Error) -> Self {
         // generally consider io errors recoverable
         // we might want to revisit this at some point
-        GetError::Io(value.into())
+        GetError::Io {
+            source: value.into(),
+        }
     }
 }

--- a/src/get/error.rs
+++ b/src/get/error.rs
@@ -3,7 +3,7 @@
 use iroh::endpoint::{self, ClosedStream};
 use n0_snafu::SpanTrace;
 use nested_enum_utils::common_fields;
-use snafu::{Backtrace, Snafu};
+use snafu::{Backtrace, IntoError, Snafu};
 
 #[common_fields({
     backtrace: Option<Backtrace>,
@@ -17,6 +17,7 @@ pub enum GetNotFoundError {
 
 /// Failures for a get operation
 #[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
 pub enum GetError {
     /// Hash not found, or a requested chunk for the hash not found.
     #[snafu(display("Data for hash not found"))]
@@ -44,17 +45,13 @@ pub type GetResult<T> = std::result::Result<T, GetError>;
 
 impl From<irpc::channel::SendError> for GetError {
     fn from(value: irpc::channel::SendError) -> Self {
-        Self::LocalFailure {
-            source: value.into(),
-        }
+        LocalFailureSnafu.into_error(value.into())
     }
 }
 
 impl<T: Send + Sync + 'static> From<tokio::sync::mpsc::error::SendError<T>> for GetError {
     fn from(value: tokio::sync::mpsc::error::SendError<T>) -> Self {
-        Self::LocalFailure {
-            source: value.into(),
-        }
+        LocalFailureSnafu.into_error(value.into())
     }
 }
 
@@ -66,40 +63,40 @@ impl From<endpoint::ConnectionError> for GetError {
             e @ ConnectionError::VersionMismatch => {
                 // > The peer doesn't implement any supported version
                 // unsupported version is likely a long time error, so this peer is not usable
-                GetError::NoncompliantNode { source: e.into() }
+                NoncompliantNodeSnafu.into_error(e.into())
             }
             e @ ConnectionError::TransportError(_) => {
                 // > The peer violated the QUIC specification as understood by this implementation
                 // bad peer we don't want to keep around
-                GetError::NoncompliantNode { source: e.into() }
+                NoncompliantNodeSnafu.into_error(e.into())
             }
             e @ ConnectionError::ConnectionClosed(_) => {
                 // > The peer's QUIC stack aborted the connection automatically
                 // peer might be disconnecting or otherwise unavailable, drop it
-                GetError::Io { source: e.into() }
+                IoSnafu.into_error(e.into())
             }
             e @ ConnectionError::ApplicationClosed(_) => {
                 // > The peer closed the connection
                 // peer might be disconnecting or otherwise unavailable, drop it
-                GetError::Io { source: e.into() }
+                IoSnafu.into_error(e.into())
             }
             e @ ConnectionError::Reset => {
                 // > The peer is unable to continue processing this connection, usually due to having restarted
-                GetError::RemoteReset { source: e.into() }
+                RemoteResetSnafu.into_error(e.into())
             }
             e @ ConnectionError::TimedOut => {
                 // > Communication with the peer has lapsed for longer than the negotiated idle timeout
-                GetError::Io { source: e.into() }
+                IoSnafu.into_error(e.into())
             }
             e @ ConnectionError::LocallyClosed => {
                 // > The local application closed the connection
                 // TODO(@divma): don't see how this is reachable but let's just not use the peer
-                GetError::Io { source: e.into() }
+                IoSnafu.into_error(e.into())
             }
             e @ ConnectionError::CidsExhausted => {
                 // > The connection could not be created because not enough of the CID space
                 // > is available
-                GetError::Io { source: e.into() }
+                IoSnafu.into_error(e.into())
             }
         }
     }
@@ -109,24 +106,20 @@ impl From<endpoint::ReadError> for GetError {
     fn from(value: endpoint::ReadError) -> Self {
         use endpoint::ReadError;
         match value {
-            e @ ReadError::Reset(_) => GetError::RemoteReset { source: e.into() },
+            e @ ReadError::Reset(_) => RemoteResetSnafu.into_error(e.into()),
             ReadError::ConnectionLost(conn_error) => conn_error.into(),
             ReadError::ClosedStream
             | ReadError::IllegalOrderedRead
             | ReadError::ZeroRttRejected => {
                 // all these errors indicate the peer is not usable at this moment
-                GetError::Io {
-                    source: value.into(),
-                }
+                IoSnafu.into_error(value.into())
             }
         }
     }
 }
 impl From<ClosedStream> for GetError {
     fn from(value: ClosedStream) -> Self {
-        GetError::Io {
-            source: value.into(),
-        }
+        IoSnafu.into_error(value.into())
     }
 }
 
@@ -134,13 +127,11 @@ impl From<quinn::WriteError> for GetError {
     fn from(value: quinn::WriteError) -> Self {
         use quinn::WriteError;
         match value {
-            e @ WriteError::Stopped(_) => GetError::RemoteReset { source: e.into() },
+            e @ WriteError::Stopped(_) => RemoteResetSnafu.into_error(e.into()),
             WriteError::ConnectionLost(conn_error) => conn_error.into(),
             WriteError::ClosedStream | WriteError::ZeroRttRejected => {
                 // all these errors indicate the peer is not usable at this moment
-                GetError::Io {
-                    source: value.into(),
-                }
+                IoSnafu.into_error(value.into())
             }
         }
     }
@@ -152,17 +143,17 @@ impl From<crate::get::fsm::ConnectedNextError> for GetError {
         match value {
             e @ PostcardSer { .. } => {
                 // serialization errors indicate something wrong with the request itself
-                GetError::BadRequest { source: e.into() }
+                BadRequestSnafu.into_error(e.into())
             }
             e @ RequestTooBig { .. } => {
                 // request will never be sent, drop it
-                GetError::BadRequest { source: e.into() }
+                BadRequestSnafu.into_error(e.into())
             }
             Write { source, .. } => source.into(),
             Closed { source, .. } => source.into(),
             e @ Io { .. } => {
                 // io errors are likely recoverable
-                GetError::Io { source: e.into() }
+                IoSnafu.into_error(e.into())
             }
         }
     }
@@ -178,17 +169,15 @@ impl From<crate::get::fsm::AtBlobHeaderNextError> for GetError {
             } => {
                 // > This indicates that the provider does not have the requested data.
                 // peer might have the data later, simply retry it
-                GetError::NotFound {
-                    source: GetNotFoundError::AtBlobHeader {
-                        backtrace,
-                        span_trace,
-                    },
-                }
+                NotFoundSnafu.into_error(GetNotFoundError::AtBlobHeader {
+                    backtrace,
+                    span_trace,
+                })
             }
             EndpointRead { source, .. } => source.into(),
             e @ Io { .. } => {
                 // io errors are likely recoverable
-                GetError::Io { source: e.into() }
+                IoSnafu.into_error(e.into())
             }
         }
     }
@@ -202,41 +191,35 @@ impl From<crate::get::fsm::DecodeError> for GetError {
             ChunkNotFound {
                 backtrace,
                 span_trace,
-            } => GetError::NotFound {
-                source: GetNotFoundError::AtBlobHeader {
-                    backtrace,
-                    span_trace,
-                },
-            },
+            } => NotFoundSnafu.into_error(GetNotFoundError::AtBlobHeader {
+                backtrace,
+                span_trace,
+            }),
             ParentNotFound {
                 backtrace,
                 span_trace,
                 ..
-            } => GetError::NotFound {
-                source: GetNotFoundError::AtBlobHeader {
-                    backtrace,
-                    span_trace,
-                },
-            },
+            } => NotFoundSnafu.into_error(GetNotFoundError::AtBlobHeader {
+                backtrace,
+                span_trace,
+            }),
             LeafNotFound {
                 backtrace,
                 span_trace,
                 ..
-            } => GetError::NotFound {
-                source: GetNotFoundError::AtBlobHeader {
-                    backtrace,
-                    span_trace,
-                },
-            },
+            } => NotFoundSnafu.into_error(GetNotFoundError::AtBlobHeader {
+                backtrace,
+                span_trace,
+            }),
             e @ ParentHashMismatch { .. } => {
                 // TODO(@divma): did the peer sent wrong data? is it corrupted? did we sent a wrong
                 // request?
-                GetError::NoncompliantNode { source: e.into() }
+                NoncompliantNodeSnafu.into_error(e.into())
             }
             e @ LeafHashMismatch { .. } => {
                 // TODO(@divma): did the peer sent wrong data? is it corrupted? did we sent a wrong
                 // request?
-                GetError::NoncompliantNode { source: e.into() }
+                NoncompliantNodeSnafu.into_error(e.into())
             }
             Read { source, .. } => source.into(),
             DecodeIo { source, .. } => source.into(),
@@ -248,8 +231,6 @@ impl From<std::io::Error> for GetError {
     fn from(value: std::io::Error) -> Self {
         // generally consider io errors recoverable
         // we might want to revisit this at some point
-        GetError::Io {
-            source: value.into(),
-        }
+        IoSnafu.into_error(value.into())
     }
 }

--- a/src/get/request.rs
+++ b/src/get/request.rs
@@ -19,11 +19,13 @@ use iroh::endpoint::Connection;
 use n0_future::{Stream, StreamExt};
 use nested_enum_utils::enum_conversions;
 use rand::Rng;
+use snafu::IntoError;
 use tokio::sync::mpsc;
 
 use super::{GetError, GetResult, Stats, fsm};
 use crate::{
     Hash, HashAndFormat,
+    get::error::{BadRequestSnafu, LocalFailureSnafu},
     hashseq::HashSeq,
     protocol::{ChunkRangesSeq, GetRequest},
     util::ChunkRangesExt,
@@ -56,9 +58,7 @@ impl GetBlobResult {
         let mut parts = Vec::new();
         let stats = loop {
             let Some(item) = self.next().await else {
-                return Err(GetError::LocalFailure {
-                    source: anyhow::anyhow!("unexpected end"),
-                });
+                return Err(LocalFailureSnafu.into_error(anyhow::anyhow!("unexpected end")));
             };
             match item {
                 GetBlobItem::Item(item) => {
@@ -238,13 +238,11 @@ pub async fn get_hash_seq_and_sizes(
     let (at_blob_content, size) = at_start_root.next().await?;
     // check the size to avoid parsing a maliciously large hash seq
     if size > max_size {
-        return Err(GetError::BadRequest {
-            source: anyhow::anyhow!("size too large"),
-        });
+        return Err(BadRequestSnafu.into_error(anyhow::anyhow!("size too large")));
     }
     let (mut curr, hash_seq) = at_blob_content.concatenate_into_vec().await?;
     let hash_seq = HashSeq::try_from(Bytes::from(hash_seq))
-        .map_err(|e| GetError::BadRequest { source: e.into() })?;
+        .map_err(|e| BadRequestSnafu.into_error(e.into()))?;
     let mut sizes = Vec::with_capacity(hash_seq.len());
     let closing = loop {
         match curr.next() {

--- a/src/get/request.rs
+++ b/src/get/request.rs
@@ -58,7 +58,7 @@ impl GetBlobResult {
         let mut parts = Vec::new();
         let stats = loop {
             let Some(item) = self.next().await else {
-                return Err(LocalFailureSnafu.into_error(anyhow::anyhow!("unexpected end")));
+                return Err(LocalFailureSnafu.into_error(anyhow::anyhow!("unexpected end").into()));
             };
             match item {
                 GetBlobItem::Item(item) => {
@@ -238,7 +238,7 @@ pub async fn get_hash_seq_and_sizes(
     let (at_blob_content, size) = at_start_root.next().await?;
     // check the size to avoid parsing a maliciously large hash seq
     if size > max_size {
-        return Err(BadRequestSnafu.into_error(anyhow::anyhow!("size too large")));
+        return Err(BadRequestSnafu.into_error(anyhow::anyhow!("size too large").into()));
     }
     let (mut curr, hash_seq) = at_blob_content.concatenate_into_vec().await?;
     let hash_seq = HashSeq::try_from(Bytes::from(hash_seq))

--- a/src/net_protocol.rs
+++ b/src/net_protocol.rs
@@ -39,11 +39,10 @@
 use std::{fmt::Debug, sync::Arc};
 
 use iroh::{
-    Endpoint,
+    Endpoint, Watcher,
     endpoint::Connection,
     protocol::{AcceptError, ProtocolHandler},
 };
-use n0_watcher::Watcher;
 use tokio::sync::mpsc;
 use tracing::error;
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -437,7 +437,7 @@ pub enum RequestType {
 
 impl Request {
     pub async fn read_async(
-        reader: &mut CountingReader<&mut quinn::RecvStream>,
+        reader: &mut CountingReader<&mut iroh::endpoint::RecvStream>,
     ) -> io::Result<Self> {
         let request_type = reader.read_u8().await?;
         let request_type: RequestType = postcard::from_bytes(std::slice::from_ref(&request_type))

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -732,7 +732,7 @@ impl<R> CountingReader<R> {
     }
 }
 
-impl CountingReader<&mut quinn::RecvStream> {
+impl CountingReader<&mut iroh::endpoint::RecvStream> {
     pub async fn read_to_end_as<T: DeserializeOwned>(&mut self, max_size: usize) -> io::Result<T> {
         let data = self
             .inner

--- a/src/store/fs/entry_state.rs
+++ b/src/store/fs/entry_state.rs
@@ -46,7 +46,7 @@ impl<X> DataLocation<X, u64> {
                 DataLocation::External(b_paths, b_size),
             ) => {
                 if a_size != b_size {
-                    return Err(ActorError::Inconsistent(format!(
+                    return Err(ActorError::inconsistent(format!(
                         "complete size mismatch {} {}",
                         a_size, b_size
                     )));
@@ -252,7 +252,7 @@ impl EntryState {
                         // least one validation was wrong, which would be a bug
                         // in bao-tree.
                         if a_size != b_size {
-                            return Err(ActorError::Inconsistent(format!(
+                            return Err(ActorError::inconsistent(format!(
                                 "validated size mismatch {} {}",
                                 a_size, b_size
                             )));

--- a/src/store/fs/meta.rs
+++ b/src/store/fs/meta.rs
@@ -10,11 +10,11 @@ use std::{
 
 use bao_tree::BaoTree;
 use bytes::Bytes;
-use irpc::channel::spsc;
+use irpc::channel::mpsc;
 use n0_snafu::SpanTrace;
 use nested_enum_utils::common_fields;
 use redb::{Database, DatabaseError, ReadableTable};
-use snafu::{Backtrace, Snafu};
+use snafu::{Backtrace, ResultExt, Snafu};
 use tokio::pin;
 
 use crate::{
@@ -52,12 +52,11 @@ use crate::store::{Hash, IROH_BLOCK_SIZE, util::Tag};
 #[common_fields({
     backtrace: Option<Backtrace>,
     #[snafu(implicit)]
-    span_trace: n0_snafu::SpanTrace,
+    span_trace: SpanTrace,
 })]
 #[allow(missing_docs)]
-#[derive(Debug, Snafu)]
 #[non_exhaustive]
-#[derive(Debug, snafu::Error)]
+#[derive(Debug, Snafu)]
 pub enum ActorError {
     #[snafu(display("table error: {source}"))]
     Table { source: redb::TableError },
@@ -69,13 +68,19 @@ pub enum ActorError {
     Commit { source: redb::CommitError },
     #[snafu(display("storage error: {source}"))]
     Storage { source: redb::StorageError },
-    #[snafu(display("inconsistent database state: {source}"))]
-    Inconsistent { source: String },
+    #[snafu(display("inconsistent database state: {msg}"))]
+    Inconsistent { msg: String },
 }
 
 impl From<ActorError> for io::Error {
     fn from(e: ActorError) -> Self {
         io::Error::other(e)
+    }
+}
+
+impl ActorError {
+    pub(super) fn inconsistent(msg: String) -> Self {
+        InconsistentSnafu { msg }.build()
     }
 }
 
@@ -124,7 +129,7 @@ impl Db {
 fn handle_get(cmd: Get, tables: &impl ReadableTables) -> ActorResult<()> {
     trace!("{cmd:?}");
     let Get { hash, tx, .. } = cmd;
-    let Some(entry) = tables.blobs().get(hash)? else {
+    let Some(entry) = tables.blobs().get(hash).context(StorageSnafu)? else {
         tx.send(GetResult { state: Ok(None) });
         return Ok(());
     };
@@ -152,26 +157,26 @@ fn handle_get(cmd: Get, tables: &impl ReadableTables) -> ActorResult<()> {
 fn handle_dump(cmd: Dump, tables: &impl ReadableTables) -> ActorResult<()> {
     trace!("{cmd:?}");
     trace!("dumping database");
-    for e in tables.blobs().iter()? {
-        let (k, v) = e?;
+    for e in tables.blobs().iter().context(StorageSnafu)? {
+        let (k, v) = e.context(StorageSnafu)?;
         let k = k.value();
         let v = v.value();
         println!("blobs: {} -> {:?}", k.to_hex(), v);
     }
-    for e in tables.tags().iter()? {
-        let (k, v) = e?;
+    for e in tables.tags().iter().context(StorageSnafu)? {
+        let (k, v) = e.context(StorageSnafu)?;
         let k = k.value();
         let v = v.value();
         println!("tags: {} -> {:?}", k, v);
     }
-    for e in tables.inline_data().iter()? {
-        let (k, v) = e?;
+    for e in tables.inline_data().iter().context(StorageSnafu)? {
+        let (k, v) = e.context(StorageSnafu)?;
         let k = k.value();
         let v = v.value();
         println!("inline_data: {} -> {:?}", k.to_hex(), v.len());
     }
-    for e in tables.inline_outboard().iter()? {
-        let (k, v) = e?;
+    for e in tables.inline_outboard().iter().context(StorageSnafu)? {
+        let (k, v) = e.context(StorageSnafu)?;
         let k = k.value();
         let v = v.value();
         println!("inline_outboard: {} -> {:?}", k.to_hex(), v.len());
@@ -200,12 +205,12 @@ async fn handle_get_blob_status(
         tx,
         ..
     } = msg;
-    let res = match tables.blobs().get(hash)? {
+    let res = match tables.blobs().get(hash).context(StorageSnafu)? {
         Some(entry) => match entry.value() {
             EntryState::Complete { data_location, .. } => match data_location {
                 DataLocation::Inline(_) => {
-                    let Some(data) = tables.inline_data().get(hash)? else {
-                        return Err(ActorError::Inconsistent(format!(
+                    let Some(data) = tables.inline_data().get(hash).context(StorageSnafu)? else {
+                        return Err(ActorError::inconsistent(format!(
                             "inconsistent database state: {} not found",
                             hash.to_hex()
                         )));
@@ -241,7 +246,7 @@ async fn handle_list_tags(msg: ListTagsMsg, tables: &impl ReadableTables) -> Act
     let from = from.map(Bound::Included).unwrap_or(Bound::Unbounded);
     let to = to.map(Bound::Excluded).unwrap_or(Bound::Unbounded);
     let mut res = Vec::new();
-    for item in tables.tags().range((from, to))? {
+    for item in tables.tags().range((from, to)).context(StorageSnafu)? {
         match item {
             Ok((k, v)) => {
                 let v = v.value();
@@ -274,7 +279,11 @@ fn handle_update(
     } = cmd;
     protected.insert(hash);
     trace!("updating hash {} to {}", hash.to_hex(), state.fmt_short());
-    let old_entry_opt = tables.blobs.get(hash)?.map(|e| e.value());
+    let old_entry_opt = tables
+        .blobs
+        .get(hash)
+        .context(StorageSnafu)?
+        .map(|e| e.value());
     let (state, data, outboard): (_, Option<Bytes>, Option<Bytes>) = match state {
         EntryState::Complete {
             data_location,
@@ -306,12 +315,18 @@ fn handle_update(
         }
         None => state,
     };
-    tables.blobs.insert(hash, state)?;
+    tables.blobs.insert(hash, state).context(StorageSnafu)?;
     if let Some(data) = data {
-        tables.inline_data.insert(hash, data.as_ref())?;
+        tables
+            .inline_data
+            .insert(hash, data.as_ref())
+            .context(StorageSnafu)?;
     }
     if let Some(outboard) = outboard {
-        tables.inline_outboard.insert(hash, outboard.as_ref())?;
+        tables
+            .inline_outboard
+            .insert(hash, outboard.as_ref())
+            .context(StorageSnafu)?;
     }
     if let Some(tx) = tx {
         tx.send(Ok(()));
@@ -343,12 +358,18 @@ fn handle_set(cmd: Set, protected: &mut HashSet<Hash>, tables: &mut Tables) -> A
         }
         EntryState::Partial { size } => (EntryState::Partial { size }, None, None),
     };
-    tables.blobs.insert(hash, state)?;
+    tables.blobs.insert(hash, state).context(StorageSnafu)?;
     if let Some(data) = data {
-        tables.inline_data.insert(hash, data.as_ref())?;
+        tables
+            .inline_data
+            .insert(hash, data.as_ref())
+            .context(StorageSnafu)?;
     }
     if let Some(outboard) = outboard {
-        tables.inline_outboard.insert(hash, outboard.as_ref())?;
+        tables
+            .inline_outboard
+            .insert(hash, outboard.as_ref())
+            .context(StorageSnafu)?;
     }
     tx.send(Ok(()));
     Ok(())
@@ -444,7 +465,7 @@ impl Actor {
             if !force && protected.contains(&hash) {
                 continue;
             }
-            if let Some(entry) = tables.blobs.remove(hash)? {
+            if let Some(entry) = tables.blobs.remove(hash).context(StorageSnafu)? {
                 match entry.value() {
                     EntryState::Complete {
                         data_location,
@@ -452,7 +473,7 @@ impl Actor {
                     } => {
                         match data_location {
                             DataLocation::Inline(_) => {
-                                tables.inline_data.remove(hash)?;
+                                tables.inline_data.remove(hash).context(StorageSnafu)?;
                             }
                             DataLocation::Owned(_) => {
                                 // mark the data for deletion
@@ -462,7 +483,7 @@ impl Actor {
                         }
                         match outboard_location {
                             OutboardLocation::Inline(_) => {
-                                tables.inline_outboard.remove(hash)?;
+                                tables.inline_outboard.remove(hash).context(StorageSnafu)?;
                             }
                             OutboardLocation::Owned => {
                                 // mark the outboard for deletion
@@ -512,7 +533,10 @@ impl Actor {
             let tag = Tag::auto(SystemTime::now(), |x| {
                 matches!(tables.tags.get(Tag(Bytes::copy_from_slice(x))), Ok(Some(_)))
             });
-            tables.tags.insert(tag.clone(), value)?;
+            tables
+                .tags
+                .insert(tag.clone(), value)
+                .context(StorageSnafu)?;
             tag
         };
         tx.send(Ok(tag.clone())).await.ok();
@@ -528,10 +552,13 @@ impl Actor {
         } = cmd;
         let from = from.map(Bound::Included).unwrap_or(Bound::Unbounded);
         let to = to.map(Bound::Excluded).unwrap_or(Bound::Unbounded);
-        let removing = tables.tags.extract_from_if((from, to), |_, _| true)?;
+        let removing = tables
+            .tags
+            .extract_from_if((from, to), |_, _| true)
+            .context(StorageSnafu)?;
         // drain the iterator to actually remove the tags
         for res in removing {
-            res?;
+            res.context(StorageSnafu)?;
         }
         tx.send(Ok(())).await.ok();
         Ok(())
@@ -544,7 +571,7 @@ impl Actor {
             tx,
             ..
         } = cmd;
-        let value = match tables.tags.remove(from)? {
+        let value = match tables.tags.remove(from).context(StorageSnafu)? {
             Some(value) => value.value(),
             None => {
                 tx.send(Err(api::Error::io(
@@ -556,7 +583,7 @@ impl Actor {
                 return Ok(());
             }
         };
-        tables.tags.insert(to, value)?;
+        tables.tags.insert(to, value).context(StorageSnafu)?;
         tx.send(Ok(())).await.ok();
         Ok(())
     }
@@ -634,8 +661,8 @@ impl Actor {
             }
             TopLevelCommand::Snapshot(cmd) => {
                 trace!("{cmd:?}");
-                let txn = db.begin_read()?;
-                let snapshot = ReadOnlyTables::new(&txn)?;
+                let txn = db.begin_read().context(TransactionSnafu)?;
+                let snapshot = ReadOnlyTables::new(&txn).context(TableSnafu)?;
                 cmd.tx.send(snapshot).ok();
                 None
             }
@@ -661,8 +688,8 @@ impl Actor {
                 Command::ReadOnly(cmd) => {
                     let op = TxnNum::Read(op);
                     self.cmds.push_back(cmd.into()).ok();
-                    let tx = db.begin_read()?;
-                    let tables = ReadOnlyTables::new(&tx)?;
+                    let tx = db.begin_read().context(TransactionSnafu)?;
+                    let tables = ReadOnlyTables::new(&tx).context(TableSnafu)?;
                     let timeout = tokio::time::sleep(self.options.max_read_duration);
                     pin!(timeout);
                     let mut n = 0;
@@ -679,8 +706,8 @@ impl Actor {
                     let op = TxnNum::Write(op);
                     self.cmds.push_back(cmd.into()).ok();
                     let ftx = self.ds.begin_write();
-                    let tx = db.begin_write()?;
-                    let mut tables = Tables::new(&tx, &ftx)?;
+                    let tx = db.begin_write().context(TransactionSnafu)?;
+                    let mut tables = Tables::new(&tx, &ftx).context(TableSnafu)?;
                     let timeout = tokio::time::sleep(self.options.max_read_duration);
                     pin!(timeout);
                     let mut n = 0;
@@ -697,7 +724,7 @@ impl Actor {
                         }
                     }
                     drop(tables);
-                    tx.commit()?;
+                    tx.commit().context(CommitSnafu)?;
                     ftx.commit();
                 }
             }
@@ -750,8 +777,8 @@ fn load_data(
 ) -> ActorResult<DataLocation<Bytes, u64>> {
     Ok(match location {
         DataLocation::Inline(()) => {
-            let Some(data) = tables.inline_data().get(hash)? else {
-                return Err(ActorError::Inconsistent(format!(
+            let Some(data) = tables.inline_data().get(hash).context(StorageSnafu)? else {
+                return Err(ActorError::inconsistent(format!(
                     "inconsistent database state: {} should have inline data but does not",
                     hash.to_hex()
                 )));
@@ -771,8 +798,8 @@ fn load_outboard(
     Ok(match location {
         OutboardLocation::NotNeeded => OutboardLocation::NotNeeded,
         OutboardLocation::Inline(_) => {
-            let Some(outboard) = tables.inline_outboard().get(hash)? else {
-                return Err(ActorError::Inconsistent(format!(
+            let Some(outboard) = tables.inline_outboard().get(hash).context(StorageSnafu)? else {
+                return Err(ActorError::inconsistent(format!(
                     "inconsistent database state: {} should have inline outboard but does not",
                     hash.to_hex()
                 )));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,10 +2,9 @@ use std::{collections::HashSet, io, ops::Range, path::PathBuf};
 
 use bao_tree::ChunkRanges;
 use bytes::Bytes;
-use iroh::{Endpoint, NodeId, protocol::Router};
+use iroh::{Endpoint, NodeId, Watcher, protocol::Router};
 use irpc::RpcMessage;
 use n0_future::{StreamExt, task::AbortOnDropHandle};
-use n0_watcher::Watcher;
 use tempfile::TempDir;
 use testresult::TestResult;
 use tokio::sync::{mpsc, watch};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,6 +5,7 @@ use bytes::Bytes;
 use iroh::{Endpoint, NodeId, protocol::Router};
 use irpc::RpcMessage;
 use n0_future::{StreamExt, task::AbortOnDropHandle};
+use n0_watcher::Watcher;
 use tempfile::TempDir;
 use testresult::TestResult;
 use tokio::sync::{mpsc, watch};
@@ -226,7 +227,7 @@ async fn two_nodes_get_blobs(
     for size in sizes {
         tts.push(store1.add_bytes(test_data(size)).await?);
     }
-    let addr1 = r1.endpoint().node_addr().await?;
+    let addr1 = r1.endpoint().node_addr().initialized().await?;
     let conn = r2.endpoint().connect(addr1, crate::ALPN).await?;
     for size in sizes {
         let hash = Hash::new(test_data(size));
@@ -259,7 +260,7 @@ async fn two_nodes_observe(
     let size = 1024 * 1024 * 8 + 1;
     let data = test_data(size);
     let (hash, bao) = create_n0_bao(&data, &ChunkRanges::all())?;
-    let addr1 = r1.endpoint().node_addr().await?;
+    let addr1 = r1.endpoint().node_addr().initialized().await?;
     let conn = r2.endpoint().connect(addr1, crate::ALPN).await?;
     let mut stream = store2
         .remote()
@@ -308,7 +309,7 @@ async fn two_nodes_get_many(
         tts.push(store1.add_bytes(test_data(size)).await?);
     }
     let hashes = tts.iter().map(|tt| tt.hash).collect::<Vec<_>>();
-    let addr1 = r1.endpoint().node_addr().await?;
+    let addr1 = r1.endpoint().node_addr().initialized().await?;
     let conn = r2.endpoint().connect(addr1, crate::ALPN).await?;
     store2
         .remote()
@@ -381,7 +382,7 @@ async fn two_nodes_push_blobs(
     for size in sizes {
         tts.push(store1.add_bytes(test_data(size)).await?);
     }
-    let addr2 = r2.endpoint().node_addr().await?;
+    let addr2 = r2.endpoint().node_addr().initialized().await?;
     let conn = r1.endpoint().connect(addr2, crate::ALPN).await?;
     for size in sizes {
         let hash = Hash::new(test_data(size));
@@ -542,7 +543,7 @@ async fn two_nodes_hash_seq(
     r2: Router,
     store2: &Store,
 ) -> TestResult<()> {
-    let addr1 = r1.endpoint().node_addr().await?;
+    let addr1 = r1.endpoint().node_addr().initialized().await?;
     let sizes = INTERESTING_SIZES;
     let root = add_test_hash_seq(store1, sizes).await?;
     let conn = r2.endpoint().connect(addr1, crate::ALPN).await?;
@@ -569,7 +570,7 @@ async fn two_nodes_hash_seq_mem() -> TestResult<()> {
 async fn two_nodes_hash_seq_progress() -> TestResult<()> {
     tracing_subscriber::fmt::try_init().ok();
     let (_testdir, (r1, store1, _), (r2, store2, _)) = two_node_test_setup_fs().await?;
-    let addr1 = r1.endpoint().node_addr().await?;
+    let addr1 = r1.endpoint().node_addr().initialized().await?;
     let sizes = INTERESTING_SIZES;
     let root = add_test_hash_seq(&store1, sizes).await?;
     let conn = r2.endpoint().connect(addr1, crate::ALPN).await?;
@@ -605,7 +606,7 @@ async fn node_serve_hash_seq() -> TestResult<()> {
     let r1 = Router::builder(endpoint)
         .accept(crate::protocol::ALPN, blobs)
         .spawn();
-    let addr1 = r1.endpoint().node_addr().await?;
+    let addr1 = r1.endpoint().node_addr().initialized().await?;
     info!("node addr: {addr1:?}");
     let endpoint2 = Endpoint::builder().discovery_n0().bind().await?;
     let conn = endpoint2.connect(addr1, crate::protocol::ALPN).await?;
@@ -636,7 +637,7 @@ async fn node_serve_blobs() -> TestResult<()> {
     let r1 = Router::builder(endpoint)
         .accept(crate::protocol::ALPN, blobs)
         .spawn();
-    let addr1 = r1.endpoint().node_addr().await?;
+    let addr1 = r1.endpoint().node_addr().initialized().await?;
     info!("node addr: {addr1:?}");
     let endpoint2 = Endpoint::builder().discovery_n0().bind().await?;
     let conn = endpoint2.connect(addr1, crate::protocol::ALPN).await?;
@@ -678,7 +679,7 @@ async fn node_smoke(store: &Store) -> TestResult<()> {
     let r1 = Router::builder(endpoint)
         .accept(crate::protocol::ALPN, blobs)
         .spawn();
-    let addr1 = r1.endpoint().node_addr().await?;
+    let addr1 = r1.endpoint().node_addr().initialized().await?;
     info!("node addr: {addr1:?}");
     let endpoint2 = Endpoint::builder().discovery_n0().bind().await?;
     let conn = endpoint2.connect(addr1, crate::protocol::ALPN).await?;

--- a/src/ticket.rs
+++ b/src/ticket.rs
@@ -81,7 +81,7 @@ impl Ticket for BlobTicket {
 
     fn from_bytes(bytes: &[u8]) -> std::result::Result<Self, ticket::ParseError> {
         let res: TicketWireFormat =
-            postcard::from_bytes(bytes).map_err(ticket::ParseError::Postcard)?;
+            postcard::from_bytes(bytes).map_err(ticket::ParseError::postcard)?;
         let TicketWireFormat::Variant0(Variant0BlobTicket { node, format, hash }) = res;
         Ok(Self {
             node: NodeAddr {

--- a/src/ticket.rs
+++ b/src/ticket.rs
@@ -79,8 +79,9 @@ impl Ticket for BlobTicket {
         postcard::to_stdvec(&data).expect("postcard serialization failed")
     }
 
-    fn from_bytes(bytes: &[u8]) -> std::result::Result<Self, ticket::Error> {
-        let res: TicketWireFormat = postcard::from_bytes(bytes).map_err(ticket::Error::Postcard)?;
+    fn from_bytes(bytes: &[u8]) -> std::result::Result<Self, ticket::ParseError> {
+        let res: TicketWireFormat =
+            postcard::from_bytes(bytes).map_err(ticket::ParseError::Postcard)?;
         let TicketWireFormat::Variant0(Variant0BlobTicket { node, format, hash }) = res;
         Ok(Self {
             node: NodeAddr {
@@ -95,7 +96,7 @@ impl Ticket for BlobTicket {
 }
 
 impl FromStr for BlobTicket {
-    type Err = ticket::Error;
+    type Err = ticket::ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ticket::deserialize(s)

--- a/src/ticket.rs
+++ b/src/ticket.rs
@@ -80,8 +80,7 @@ impl Ticket for BlobTicket {
     }
 
     fn from_bytes(bytes: &[u8]) -> std::result::Result<Self, ticket::ParseError> {
-        let res: TicketWireFormat =
-            postcard::from_bytes(bytes).map_err(ticket::ParseError::postcard)?;
+        let res: TicketWireFormat = postcard::from_bytes(bytes)?;
         let TicketWireFormat::Variant0(Variant0BlobTicket { node, format, hash }) = res;
         Ok(Self {
             node: NodeAddr {


### PR DESCRIPTION
@ramfox I think this one is the best of 2 bad alternatives. WDYT?

At least all the plumbing does not appear in the docs since the XXXCases enums are in a private module...